### PR TITLE
Add v1beta1 api and update swagger specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+*.iml
 
 doc

--- a/resources/swagger/v1.json
+++ b/resources/swagger/v1.json
@@ -3,6 +3,10 @@
   "apiVersion": "v1",
   "basePath": "https://10.10.10.10:6443",
   "resourcePath": "/api/v1",
+  "info": {
+   "title": "",
+   "description": ""
+  },
   "apis": [
    {
     "path": "/api/v1/namespaces/{namespace}/bindings",
@@ -47,7 +51,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -63,7 +69,7 @@
       "type": "v1.ComponentStatusList",
       "method": "GET",
       "summary": "list objects of kind ComponentStatus",
-      "nickname": "listNamespacedComponentStatus",
+      "nickname": "listComponentStatus",
       "parameters": [
        {
         "type": "string",
@@ -122,7 +128,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -138,7 +148,7 @@
       "type": "v1.ComponentStatus",
       "method": "GET",
       "summary": "read the specified ComponentStatus",
-      "nickname": "readNamespacedComponentStatus",
+      "nickname": "readComponentStatus",
       "parameters": [
        {
         "type": "string",
@@ -165,7 +175,814 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespace}/configmaps",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.ConfigMapList",
+      "method": "GET",
+      "summary": "list or watch objects of kind ConfigMap",
+      "nickname": "listNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ConfigMapList"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.ConfigMap",
+      "method": "POST",
+      "summary": "create a ConfigMap",
+      "nickname": "createNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.ConfigMap",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ConfigMap"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of ConfigMap",
+      "nickname": "deletecollectionNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/namespaces/{namespace}/configmaps",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "versioned.Event",
+      "method": "GET",
+      "summary": "watch individual changes to a list of ConfigMap",
+      "nickname": "watchNamespacedConfigMapList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespace}/configmaps/{name}",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.ConfigMap",
+      "method": "GET",
+      "summary": "read the specified ConfigMap",
+      "nickname": "readNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ConfigMap",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ConfigMap"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.ConfigMap",
+      "method": "PUT",
+      "summary": "replace the specified ConfigMap",
+      "nickname": "replaceNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.ConfigMap",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ConfigMap",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ConfigMap"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.ConfigMap",
+      "method": "PATCH",
+      "summary": "partially update the specified ConfigMap",
+      "nickname": "patchNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ConfigMap",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ConfigMap"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete a ConfigMap",
+      "nickname": "deleteNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.DeleteOptions",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ConfigMap",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/namespaces/{namespace}/configmaps/{name}",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "versioned.Event",
+      "method": "GET",
+      "summary": "watch changes to an object of kind ConfigMap",
+      "nickname": "watchNamespacedConfigMap",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ConfigMap",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/configmaps",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.ConfigMapList",
+      "method": "GET",
+      "summary": "list or watch objects of kind ConfigMap",
+      "nickname": "listConfigMapForAllNamespaces",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ConfigMapList"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/configmaps",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "versioned.Event",
+      "method": "GET",
+      "summary": "watch individual changes to a list of ConfigMap",
+      "nickname": "watchConfigMapListForAllNamespaces",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -248,7 +1065,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -257,7 +1078,7 @@
      {
       "type": "v1.Endpoints",
       "method": "POST",
-      "summary": "create a Endpoints",
+      "summary": "create Endpoints",
       "nickname": "createNamespacedEndpoints",
       "parameters": [
        {
@@ -293,7 +1114,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of Endpoints",
+      "nickname": "deletecollectionNamespacedEndpoints",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -306,7 +1208,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Endpoints",
       "nickname": "watchNamespacedEndpointsList",
@@ -372,11 +1274,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -399,6 +1305,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -427,7 +1349,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -480,7 +1404,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -533,7 +1459,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -544,7 +1472,7 @@
      {
       "type": "unversioned.Status",
       "method": "DELETE",
-      "summary": "delete a Endpoints",
+      "summary": "delete Endpoints",
       "nickname": "deleteNamespacedEndpoints",
       "parameters": [
        {
@@ -561,6 +1489,22 @@
         "name": "body",
         "description": "",
         "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
         "allowMultiple": false
        },
        {
@@ -588,7 +1532,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -601,7 +1547,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Endpoints",
       "nickname": "watchNamespacedEndpoints",
@@ -675,11 +1621,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -695,7 +1645,7 @@
       "type": "v1.EndpointsList",
       "method": "GET",
       "summary": "list or watch objects of kind Endpoints",
-      "nickname": "listEndpoints",
+      "nickname": "listEndpointsForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -754,7 +1704,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -767,10 +1721,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Endpoints",
-      "nickname": "watchEndpointsList",
+      "nickname": "watchEndpointsListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -825,11 +1779,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -912,7 +1870,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -921,7 +1883,7 @@
      {
       "type": "v1.Event",
       "method": "POST",
-      "summary": "create a Event",
+      "summary": "create an Event",
       "nickname": "createNamespacedEvent",
       "parameters": [
        {
@@ -957,7 +1919,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of Event",
+      "nickname": "deletecollectionNamespacedEvent",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -970,7 +2013,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Event",
       "nickname": "watchNamespacedEventList",
@@ -1036,11 +2079,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -1063,6 +2110,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -1091,7 +2154,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1144,7 +2209,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1197,7 +2264,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -1208,7 +2277,7 @@
      {
       "type": "unversioned.Status",
       "method": "DELETE",
-      "summary": "delete a Event",
+      "summary": "delete an Event",
       "nickname": "deleteNamespacedEvent",
       "parameters": [
        {
@@ -1225,6 +2294,22 @@
         "name": "body",
         "description": "",
         "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
         "allowMultiple": false
        },
        {
@@ -1252,7 +2337,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1265,7 +2352,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Event",
       "nickname": "watchNamespacedEvent",
@@ -1339,11 +2426,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -1359,7 +2450,7 @@
       "type": "v1.EventList",
       "method": "GET",
       "summary": "list or watch objects of kind Event",
-      "nickname": "listEvent",
+      "nickname": "listEventForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1418,7 +2509,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -1431,10 +2526,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Event",
-      "nickname": "watchEventList",
+      "nickname": "watchEventListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -1489,11 +2584,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -1576,7 +2675,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -1621,7 +2724,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of LimitRange",
+      "nickname": "deletecollectionNamespacedLimitRange",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1634,7 +2818,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of LimitRange",
       "nickname": "watchNamespacedLimitRangeList",
@@ -1700,11 +2884,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -1727,6 +2915,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -1755,7 +2959,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1808,7 +3014,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1861,7 +3069,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -1892,6 +3102,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -1916,7 +3142,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -1929,7 +3157,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind LimitRange",
       "nickname": "watchNamespacedLimitRange",
@@ -2003,11 +3231,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2023,7 +3255,7 @@
       "type": "v1.LimitRangeList",
       "method": "GET",
       "summary": "list or watch objects of kind LimitRange",
-      "nickname": "listLimitRange",
+      "nickname": "listLimitRangeForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2082,7 +3314,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2095,10 +3331,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of LimitRange",
-      "nickname": "watchLimitRangeList",
+      "nickname": "watchLimitRangeListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -2153,11 +3389,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2173,7 +3413,7 @@
       "type": "v1.NamespaceList",
       "method": "GET",
       "summary": "list or watch objects of kind Namespace",
-      "nickname": "listNamespacedNamespace",
+      "nickname": "listNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2232,7 +3472,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2242,7 +3486,7 @@
       "type": "v1.Namespace",
       "method": "POST",
       "summary": "create a Namespace",
-      "nickname": "createNamespacedNamespace",
+      "nickname": "createNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2269,23 +3513,19 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
       ]
-     }
-    ]
-   },
-   {
-    "path": "/api/v1/watch/namespaces",
-    "description": "API at /api/v1",
-    "operations": [
+     },
      {
-      "type": "json.WatchEvent",
-      "method": "GET",
-      "summary": "watch individual changes to a list of Namespace",
-      "nickname": "watchNamespacedNamespaceList",
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of Namespace",
+      "nickname": "deletecollectionNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2340,11 +3580,92 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "unversioned.Status"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/namespaces",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "versioned.Event",
+      "method": "GET",
+      "summary": "watch individual changes to a list of Namespace",
+      "nickname": "watchNamespaceList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2360,13 +3681,29 @@
       "type": "v1.Namespace",
       "method": "GET",
       "summary": "read the specified Namespace",
-      "nickname": "readNamespacedNamespace",
+      "nickname": "readNamespace",
       "parameters": [
        {
         "type": "string",
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -2387,7 +3724,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -2397,7 +3736,7 @@
       "type": "v1.Namespace",
       "method": "PUT",
       "summary": "replace the specified Namespace",
-      "nickname": "replaceNamespacedNamespace",
+      "nickname": "replaceNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2432,7 +3771,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -2442,7 +3783,7 @@
       "type": "v1.Namespace",
       "method": "PATCH",
       "summary": "partially update the specified Namespace",
-      "nickname": "patchNamespacedNamespace",
+      "nickname": "patchNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2477,7 +3818,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -2489,7 +3832,7 @@
       "type": "unversioned.Status",
       "method": "DELETE",
       "summary": "delete a Namespace",
-      "nickname": "deleteNamespacedNamespace",
+      "nickname": "deleteNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2505,6 +3848,22 @@
         "name": "body",
         "description": "",
         "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
         "allowMultiple": false
        },
        {
@@ -2524,7 +3883,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -2537,10 +3898,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Namespace",
-      "nickname": "watchNamespacedNamespace",
+      "nickname": "watchNamespace",
       "parameters": [
        {
         "type": "string",
@@ -2603,11 +3964,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2623,7 +3988,7 @@
       "type": "v1.Namespace",
       "method": "PUT",
       "summary": "replace finalize of the specified Namespace",
-      "nickname": "replaceNamespacedNamespaceFinalize",
+      "nickname": "replaceNamespaceFinalize",
       "parameters": [
        {
         "type": "string",
@@ -2658,7 +4023,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -2672,9 +4039,48 @@
     "operations": [
      {
       "type": "v1.Namespace",
+      "method": "GET",
+      "summary": "read status of the specified Namespace",
+      "nickname": "readNamespaceStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Namespace"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Namespace",
       "method": "PUT",
       "summary": "replace status of the specified Namespace",
-      "nickname": "replaceNamespacedNamespaceStatus",
+      "nickname": "replaceNamespaceStatus",
       "parameters": [
        {
         "type": "string",
@@ -2709,10 +4115,61 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.Namespace",
+      "method": "PATCH",
+      "summary": "partially update status of the specified Namespace",
+      "nickname": "patchNamespaceStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Namespace",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Namespace"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -2725,7 +4182,7 @@
       "type": "v1.NodeList",
       "method": "GET",
       "summary": "list or watch objects of kind Node",
-      "nickname": "listNamespacedNode",
+      "nickname": "listNode",
       "parameters": [
        {
         "type": "string",
@@ -2784,7 +4241,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2794,7 +4255,7 @@
       "type": "v1.Node",
       "method": "POST",
       "summary": "create a Node",
-      "nickname": "createNamespacedNode",
+      "nickname": "createNode",
       "parameters": [
        {
         "type": "string",
@@ -2821,23 +4282,19 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
       ]
-     }
-    ]
-   },
-   {
-    "path": "/api/v1/watch/nodes",
-    "description": "API at /api/v1",
-    "operations": [
+     },
      {
-      "type": "json.WatchEvent",
-      "method": "GET",
-      "summary": "watch individual changes to a list of Node",
-      "nickname": "watchNamespacedNodeList",
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of Node",
+      "nickname": "deletecollectionNode",
       "parameters": [
        {
         "type": "string",
@@ -2892,11 +4349,92 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "unversioned.Status"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/nodes",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "versioned.Event",
+      "method": "GET",
+      "summary": "watch individual changes to a list of Node",
+      "nickname": "watchNodeList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -2912,13 +4450,29 @@
       "type": "v1.Node",
       "method": "GET",
       "summary": "read the specified Node",
-      "nickname": "readNamespacedNode",
+      "nickname": "readNode",
       "parameters": [
        {
         "type": "string",
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -2939,7 +4493,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -2949,7 +4505,7 @@
       "type": "v1.Node",
       "method": "PUT",
       "summary": "replace the specified Node",
-      "nickname": "replaceNamespacedNode",
+      "nickname": "replaceNode",
       "parameters": [
        {
         "type": "string",
@@ -2984,7 +4540,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -2994,7 +4552,7 @@
       "type": "v1.Node",
       "method": "PATCH",
       "summary": "partially update the specified Node",
-      "nickname": "patchNamespacedNode",
+      "nickname": "patchNode",
       "parameters": [
        {
         "type": "string",
@@ -3029,7 +4587,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -3041,7 +4601,7 @@
       "type": "unversioned.Status",
       "method": "DELETE",
       "summary": "delete a Node",
-      "nickname": "deleteNamespacedNode",
+      "nickname": "deleteNode",
       "parameters": [
        {
         "type": "string",
@@ -3057,6 +4617,22 @@
         "name": "body",
         "description": "",
         "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
         "allowMultiple": false
        },
        {
@@ -3076,7 +4652,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -3089,10 +4667,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Node",
-      "nickname": "watchNamespacedNode",
+      "nickname": "watchNode",
       "parameters": [
        {
         "type": "string",
@@ -3155,11 +4733,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -3168,14 +4750,14 @@
     ]
    },
    {
-    "path": "/api/v1/proxy/nodes/{name}/{path:*}",
+    "path": "/api/v1/proxy/nodes/{name}/{path}",
     "description": "API at /api/v1",
     "operations": [
      {
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Node",
-      "nickname": "proxyGETNamespacedNode",
+      "nickname": "proxyGETNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -3205,7 +4787,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Node",
-      "nickname": "proxyPUTNamespacedNode",
+      "nickname": "proxyPUTNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -3235,7 +4817,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Node",
-      "nickname": "proxyPOSTNamespacedNode",
+      "nickname": "proxyPOSTNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -3265,7 +4847,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Node",
-      "nickname": "proxyDELETENamespacedNode",
+      "nickname": "proxyDELETENodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -3295,7 +4877,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Node",
-      "nickname": "proxyHEADNamespacedNode",
+      "nickname": "proxyHEADNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -3325,7 +4907,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Node",
-      "nickname": "proxyOPTIONSNamespacedNode",
+      "nickname": "proxyOPTIONSNodeWithPath",
       "parameters": [
        {
         "type": "string",
@@ -3361,7 +4943,7 @@
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Node",
-      "nickname": "proxyGETNamespacedNode",
+      "nickname": "proxyGETNode",
       "parameters": [
        {
         "type": "string",
@@ -3383,7 +4965,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Node",
-      "nickname": "proxyPUTNamespacedNode",
+      "nickname": "proxyPUTNode",
       "parameters": [
        {
         "type": "string",
@@ -3405,7 +4987,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Node",
-      "nickname": "proxyPOSTNamespacedNode",
+      "nickname": "proxyPOSTNode",
       "parameters": [
        {
         "type": "string",
@@ -3427,7 +5009,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Node",
-      "nickname": "proxyDELETENamespacedNode",
+      "nickname": "proxyDELETENode",
       "parameters": [
        {
         "type": "string",
@@ -3449,7 +5031,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Node",
-      "nickname": "proxyHEADNamespacedNode",
+      "nickname": "proxyHEADNode",
       "parameters": [
        {
         "type": "string",
@@ -3471,7 +5053,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Node",
-      "nickname": "proxyOPTIONSNamespacedNode",
+      "nickname": "proxyOPTIONSNode",
       "parameters": [
        {
         "type": "string",
@@ -3492,14 +5074,473 @@
     ]
    },
    {
+    "path": "/api/v1/nodes/{name}/proxy",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "string",
+      "method": "GET",
+      "summary": "connect GET requests to proxy of Node",
+      "nickname": "connectGetNodeProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to proxy of Node",
+      "nickname": "connectPostNodeProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "PUT",
+      "summary": "connect PUT requests to proxy of Node",
+      "nickname": "connectPutNodeProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "DELETE",
+      "summary": "connect DELETE requests to proxy of Node",
+      "nickname": "connectDeleteNodeProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "HEAD",
+      "summary": "connect HEAD requests to proxy of Node",
+      "nickname": "connectHeadNodeProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "OPTIONS",
+      "summary": "connect OPTIONS requests to proxy of Node",
+      "nickname": "connectOptionsNodeProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/nodes/{name}/proxy/{path}",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "string",
+      "method": "GET",
+      "summary": "connect GET requests to proxy of Node",
+      "nickname": "connectGetNodeProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to proxy of Node",
+      "nickname": "connectPostNodeProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "PUT",
+      "summary": "connect PUT requests to proxy of Node",
+      "nickname": "connectPutNodeProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "DELETE",
+      "summary": "connect DELETE requests to proxy of Node",
+      "nickname": "connectDeleteNodeProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "HEAD",
+      "summary": "connect HEAD requests to proxy of Node",
+      "nickname": "connectHeadNodeProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "OPTIONS",
+      "summary": "connect OPTIONS requests to proxy of Node",
+      "nickname": "connectOptionsNodeProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the URL path to use for the current proxy request to node.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/api/v1/nodes/{name}/status",
     "description": "API at /api/v1",
     "operations": [
      {
       "type": "v1.Node",
+      "method": "GET",
+      "summary": "read status of the specified Node",
+      "nickname": "readNodeStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Node"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Node",
       "method": "PUT",
       "summary": "replace status of the specified Node",
-      "nickname": "replaceNamespacedNodeStatus",
+      "nickname": "replaceNodeStatus",
       "parameters": [
        {
         "type": "string",
@@ -3534,10 +5575,61 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.Node",
+      "method": "PATCH",
+      "summary": "partially update status of the specified Node",
+      "nickname": "patchNodeStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Node",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Node"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -3617,7 +5709,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -3662,7 +5758,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of PersistentVolumeClaim",
+      "nickname": "deletecollectionNamespacedPersistentVolumeClaim",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -3675,7 +5852,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PersistentVolumeClaim",
       "nickname": "watchNamespacedPersistentVolumeClaimList",
@@ -3741,11 +5918,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -3768,6 +5949,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -3796,7 +5993,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -3849,7 +6048,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -3902,7 +6103,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -3933,6 +6136,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -3957,7 +6176,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -3970,7 +6191,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind PersistentVolumeClaim",
       "nickname": "watchNamespacedPersistentVolumeClaim",
@@ -4044,11 +6265,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4064,7 +6289,7 @@
       "type": "v1.PersistentVolumeClaimList",
       "method": "GET",
       "summary": "list or watch objects of kind PersistentVolumeClaim",
-      "nickname": "listPersistentVolumeClaim",
+      "nickname": "listPersistentVolumeClaimForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -4123,7 +6348,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4136,10 +6365,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PersistentVolumeClaim",
-      "nickname": "watchPersistentVolumeClaimList",
+      "nickname": "watchPersistentVolumeClaimListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -4194,11 +6423,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4210,6 +6443,53 @@
     "path": "/api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status",
     "description": "API at /api/v1",
     "operations": [
+     {
+      "type": "v1.PersistentVolumeClaim",
+      "method": "GET",
+      "summary": "read status of the specified PersistentVolumeClaim",
+      "nickname": "readNamespacedPersistentVolumeClaimStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the PersistentVolumeClaim",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.PersistentVolumeClaim"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
      {
       "type": "v1.PersistentVolumeClaim",
       "method": "PUT",
@@ -4257,10 +6537,69 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.PersistentVolumeClaim",
+      "method": "PATCH",
+      "summary": "partially update status of the specified PersistentVolumeClaim",
+      "nickname": "patchNamespacedPersistentVolumeClaimStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the PersistentVolumeClaim",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.PersistentVolumeClaim"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -4273,7 +6612,7 @@
       "type": "v1.PersistentVolumeList",
       "method": "GET",
       "summary": "list or watch objects of kind PersistentVolume",
-      "nickname": "listNamespacedPersistentVolume",
+      "nickname": "listPersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4332,7 +6671,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4342,7 +6685,7 @@
       "type": "v1.PersistentVolume",
       "method": "POST",
       "summary": "create a PersistentVolume",
-      "nickname": "createNamespacedPersistentVolume",
+      "nickname": "createPersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4369,23 +6712,19 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
       ]
-     }
-    ]
-   },
-   {
-    "path": "/api/v1/watch/persistentvolumes",
-    "description": "API at /api/v1",
-    "operations": [
+     },
      {
-      "type": "json.WatchEvent",
-      "method": "GET",
-      "summary": "watch individual changes to a list of PersistentVolume",
-      "nickname": "watchNamespacedPersistentVolumeList",
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of PersistentVolume",
+      "nickname": "deletecollectionPersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4440,11 +6779,92 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "unversioned.Status"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/watch/persistentvolumes",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "versioned.Event",
+      "method": "GET",
+      "summary": "watch individual changes to a list of PersistentVolume",
+      "nickname": "watchPersistentVolumeList",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "versioned.Event"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4460,13 +6880,29 @@
       "type": "v1.PersistentVolume",
       "method": "GET",
       "summary": "read the specified PersistentVolume",
-      "nickname": "readNamespacedPersistentVolume",
+      "nickname": "readPersistentVolume",
       "parameters": [
        {
         "type": "string",
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -4487,7 +6923,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -4497,7 +6935,7 @@
       "type": "v1.PersistentVolume",
       "method": "PUT",
       "summary": "replace the specified PersistentVolume",
-      "nickname": "replaceNamespacedPersistentVolume",
+      "nickname": "replacePersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4532,7 +6970,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -4542,7 +6982,7 @@
       "type": "v1.PersistentVolume",
       "method": "PATCH",
       "summary": "partially update the specified PersistentVolume",
-      "nickname": "patchNamespacedPersistentVolume",
+      "nickname": "patchPersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4577,7 +7017,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -4589,7 +7031,7 @@
       "type": "unversioned.Status",
       "method": "DELETE",
       "summary": "delete a PersistentVolume",
-      "nickname": "deleteNamespacedPersistentVolume",
+      "nickname": "deletePersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4605,6 +7047,22 @@
         "name": "body",
         "description": "",
         "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
         "allowMultiple": false
        },
        {
@@ -4624,7 +7082,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -4637,10 +7097,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind PersistentVolume",
-      "nickname": "watchNamespacedPersistentVolume",
+      "nickname": "watchPersistentVolume",
       "parameters": [
        {
         "type": "string",
@@ -4703,11 +7163,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4721,9 +7185,48 @@
     "operations": [
      {
       "type": "v1.PersistentVolume",
+      "method": "GET",
+      "summary": "read status of the specified PersistentVolume",
+      "nickname": "readPersistentVolumeStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the PersistentVolume",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.PersistentVolume"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.PersistentVolume",
       "method": "PUT",
       "summary": "replace status of the specified PersistentVolume",
-      "nickname": "replaceNamespacedPersistentVolumeStatus",
+      "nickname": "replacePersistentVolumeStatus",
       "parameters": [
        {
         "type": "string",
@@ -4758,10 +7261,61 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.PersistentVolume",
+      "method": "PATCH",
+      "summary": "partially update status of the specified PersistentVolume",
+      "nickname": "patchPersistentVolumeStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the PersistentVolume",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.PersistentVolume"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -4841,7 +7395,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4886,7 +7444,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of Pod",
+      "nickname": "deletecollectionNamespacedPod",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -4899,7 +7538,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Pod",
       "nickname": "watchNamespacedPodList",
@@ -4965,11 +7604,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -4992,6 +7635,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -5020,7 +7679,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -5073,7 +7734,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -5126,7 +7789,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -5157,6 +7822,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -5181,7 +7862,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -5194,7 +7877,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Pod",
       "nickname": "watchNamespacedPod",
@@ -5268,11 +7951,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -5281,14 +7968,14 @@
     ]
    },
    {
-    "path": "/api/v1/proxy/namespaces/{namespace}/pods/{name}/{path:*}",
+    "path": "/api/v1/proxy/namespaces/{namespace}/pods/{name}/{path}",
     "description": "API at /api/v1",
     "operations": [
      {
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Pod",
-      "nickname": "proxyGETNamespacedPod",
+      "nickname": "proxyGETNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5326,7 +8013,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Pod",
-      "nickname": "proxyPUTNamespacedPod",
+      "nickname": "proxyPUTNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5364,7 +8051,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Pod",
-      "nickname": "proxyPOSTNamespacedPod",
+      "nickname": "proxyPOSTNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5402,7 +8089,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Pod",
-      "nickname": "proxyDELETENamespacedPod",
+      "nickname": "proxyDELETENamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5440,7 +8127,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Pod",
-      "nickname": "proxyHEADNamespacedPod",
+      "nickname": "proxyHEADNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5478,7 +8165,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Pod",
-      "nickname": "proxyOPTIONSNamespacedPod",
+      "nickname": "proxyOPTIONSNamespacedPodWithPath",
       "parameters": [
        {
         "type": "string",
@@ -5708,7 +8395,7 @@
       "type": "v1.PodList",
       "method": "GET",
       "summary": "list or watch objects of kind Pod",
-      "nickname": "listPod",
+      "nickname": "listPodForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -5767,7 +8454,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -5780,10 +8471,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Pod",
-      "nickname": "watchPodList",
+      "nickname": "watchPodListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -5838,11 +8529,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -6047,7 +8742,70 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespace}/pods/{name}/eviction",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1beta1.Eviction",
+      "method": "POST",
+      "summary": "create eviction of an Eviction",
+      "nickname": "createNamespacedEvictionEviction",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1beta1.Eviction",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Eviction",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1beta1.Eviction"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -6222,7 +8980,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "v1.Pod",
+      "type": "string",
       "method": "GET",
       "summary": "read log of the specified Pod",
       "nickname": "readNamespacedPodLog",
@@ -6271,7 +9029,7 @@
         "type": "string",
         "paramType": "query",
         "name": "sinceTime",
-        "description": "An RFC3339 timestamp from which to show logs. If this value preceeds the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
+        "description": "An RFC3339 timestamp from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
         "required": false,
         "allowMultiple": false
        },
@@ -6320,11 +9078,14 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "v1.Pod"
+        "responseModel": "string"
        }
       ],
       "produces": [
-       "application/json"
+       "text/plain",
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -6633,14 +9394,14 @@
     ]
    },
    {
-    "path": "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path:*}",
+    "path": "/api/v1/namespaces/{namespace}/pods/{name}/proxy/{path}",
     "description": "API at /api/v1",
     "operations": [
      {
       "type": "string",
       "method": "GET",
       "summary": "connect GET requests to proxy of Pod",
-      "nickname": "connectGetNamespacedPodProxy",
+      "nickname": "connectGetNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6686,7 +9447,7 @@
       "type": "string",
       "method": "POST",
       "summary": "connect POST requests to proxy of Pod",
-      "nickname": "connectPostNamespacedPodProxy",
+      "nickname": "connectPostNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6732,7 +9493,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "connect PUT requests to proxy of Pod",
-      "nickname": "connectPutNamespacedPodProxy",
+      "nickname": "connectPutNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6778,7 +9539,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "connect DELETE requests to proxy of Pod",
-      "nickname": "connectDeleteNamespacedPodProxy",
+      "nickname": "connectDeleteNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6824,7 +9585,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "connect HEAD requests to proxy of Pod",
-      "nickname": "connectHeadNamespacedPodProxy",
+      "nickname": "connectHeadNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6870,7 +9631,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "connect OPTIONS requests to proxy of Pod",
-      "nickname": "connectOptionsNamespacedPodProxy",
+      "nickname": "connectOptionsNamespacedPodProxyWithPath",
       "parameters": [
        {
         "type": "string",
@@ -6920,6 +9681,53 @@
     "operations": [
      {
       "type": "v1.Pod",
+      "method": "GET",
+      "summary": "read status of the specified Pod",
+      "nickname": "readNamespacedPodStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Pod"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Pod",
       "method": "PUT",
       "summary": "replace status of the specified Pod",
       "nickname": "replaceNamespacedPodStatus",
@@ -6965,10 +9773,69 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.Pod",
+      "method": "PATCH",
+      "summary": "partially update status of the specified Pod",
+      "nickname": "patchNamespacedPodStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Pod",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Pod"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -7048,7 +9915,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7093,7 +9964,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of PodTemplate",
+      "nickname": "deletecollectionNamespacedPodTemplate",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7106,7 +10058,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PodTemplate",
       "nickname": "watchNamespacedPodTemplateList",
@@ -7172,11 +10124,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7199,6 +10155,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -7227,7 +10199,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7280,7 +10254,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7333,7 +10309,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -7364,6 +10342,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -7388,7 +10382,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7401,7 +10397,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind PodTemplate",
       "nickname": "watchNamespacedPodTemplate",
@@ -7475,11 +10471,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7495,7 +10495,7 @@
       "type": "v1.PodTemplateList",
       "method": "GET",
       "summary": "list or watch objects of kind PodTemplate",
-      "nickname": "listPodTemplate",
+      "nickname": "listPodTemplateForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -7554,7 +10554,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7567,10 +10571,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of PodTemplate",
-      "nickname": "watchPodTemplateList",
+      "nickname": "watchPodTemplateListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -7625,11 +10629,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7712,7 +10720,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7757,7 +10769,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of ReplicationController",
+      "nickname": "deletecollectionNamespacedReplicationController",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7770,7 +10863,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ReplicationController",
       "nickname": "watchNamespacedReplicationControllerList",
@@ -7836,11 +10929,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -7863,6 +10960,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -7891,7 +11004,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7944,7 +11059,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -7997,7 +11114,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -8028,6 +11147,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -8052,7 +11187,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -8065,7 +11202,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind ReplicationController",
       "nickname": "watchNamespacedReplicationController",
@@ -8139,11 +11276,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8159,7 +11300,7 @@
       "type": "v1.ReplicationControllerList",
       "method": "GET",
       "summary": "list or watch objects of kind ReplicationController",
-      "nickname": "listReplicationController",
+      "nickname": "listReplicationControllerForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -8218,7 +11359,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8231,10 +11376,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ReplicationController",
-      "nickname": "watchReplicationControllerList",
+      "nickname": "watchReplicationControllerListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -8289,11 +11434,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8302,9 +11451,221 @@
     ]
    },
    {
+    "path": "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.Scale",
+      "method": "GET",
+      "summary": "read scale of the specified Scale",
+      "nickname": "readNamespacedScaleScale",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Scale",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Scale"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Scale",
+      "method": "PUT",
+      "summary": "replace scale of the specified Scale",
+      "nickname": "replaceNamespacedScaleScale",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.Scale",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Scale",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Scale"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Scale",
+      "method": "PATCH",
+      "summary": "partially update scale of the specified Scale",
+      "nickname": "patchNamespacedScaleScale",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Scale",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Scale"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status",
     "description": "API at /api/v1",
     "operations": [
+     {
+      "type": "v1.ReplicationController",
+      "method": "GET",
+      "summary": "read status of the specified ReplicationController",
+      "nickname": "readNamespacedReplicationControllerStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ReplicationController"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
      {
       "type": "v1.ReplicationController",
       "method": "PUT",
@@ -8352,10 +11713,69 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.ReplicationController",
+      "method": "PATCH",
+      "summary": "partially update status of the specified ReplicationController",
+      "nickname": "patchNamespacedReplicationControllerStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ReplicationController"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -8435,7 +11855,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8480,7 +11904,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of ResourceQuota",
+      "nickname": "deletecollectionNamespacedResourceQuota",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -8493,7 +11998,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ResourceQuota",
       "nickname": "watchNamespacedResourceQuotaList",
@@ -8559,11 +12064,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8586,6 +12095,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -8614,7 +12139,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -8667,7 +12194,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -8720,7 +12249,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -8751,6 +12282,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -8775,7 +12322,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -8788,7 +12337,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind ResourceQuota",
       "nickname": "watchNamespacedResourceQuota",
@@ -8862,11 +12411,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8882,7 +12435,7 @@
       "type": "v1.ResourceQuotaList",
       "method": "GET",
       "summary": "list or watch objects of kind ResourceQuota",
-      "nickname": "listResourceQuota",
+      "nickname": "listResourceQuotaForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -8941,7 +12494,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -8954,10 +12511,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ResourceQuota",
-      "nickname": "watchResourceQuotaList",
+      "nickname": "watchResourceQuotaListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -9012,11 +12569,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9028,6 +12589,53 @@
     "path": "/api/v1/namespaces/{namespace}/resourcequotas/{name}/status",
     "description": "API at /api/v1",
     "operations": [
+     {
+      "type": "v1.ResourceQuota",
+      "method": "GET",
+      "summary": "read status of the specified ResourceQuota",
+      "nickname": "readNamespacedResourceQuotaStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ResourceQuota"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
      {
       "type": "v1.ResourceQuota",
       "method": "PUT",
@@ -9075,10 +12683,69 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
+      ]
+     },
+     {
+      "type": "v1.ResourceQuota",
+      "method": "PATCH",
+      "summary": "partially update status of the specified ResourceQuota",
+      "nickname": "patchNamespacedResourceQuotaStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ResourceQuota",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ResourceQuota"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -9158,7 +12825,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9203,7 +12874,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of Secret",
+      "nickname": "deletecollectionNamespacedSecret",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -9216,7 +12968,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Secret",
       "nickname": "watchNamespacedSecretList",
@@ -9282,11 +13034,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9309,6 +13065,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -9337,7 +13109,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -9390,7 +13164,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -9443,7 +13219,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -9474,6 +13252,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -9498,7 +13292,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -9511,7 +13307,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Secret",
       "nickname": "watchNamespacedSecret",
@@ -9585,11 +13381,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9605,7 +13405,7 @@
       "type": "v1.SecretList",
       "method": "GET",
       "summary": "list or watch objects of kind Secret",
-      "nickname": "listSecret",
+      "nickname": "listSecretForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -9664,7 +13464,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9677,10 +13481,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Secret",
-      "nickname": "watchSecretList",
+      "nickname": "watchSecretListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -9735,11 +13539,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9822,7 +13630,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9867,7 +13679,88 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "unversioned.Status",
+      "method": "DELETE",
+      "summary": "delete collection of ServiceAccount",
+      "nickname": "deletecollectionNamespacedServiceAccount",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "labelSelector",
+        "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "fieldSelector",
+        "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "watch",
+        "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "resourceVersion",
+        "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "integer",
+        "paramType": "query",
+        "name": "timeoutSeconds",
+        "description": "Timeout for the list/watch call.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "unversioned.Status"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -9880,7 +13773,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ServiceAccount",
       "nickname": "watchNamespacedServiceAccountList",
@@ -9946,11 +13839,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -9973,6 +13870,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -10001,7 +13914,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10054,7 +13969,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10107,7 +14024,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -10138,6 +14057,22 @@
         "allowMultiple": false
        },
        {
+        "type": "integer",
+        "paramType": "query",
+        "name": "gracePeriodSeconds",
+        "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "orphanDependents",
+        "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
         "type": "string",
         "paramType": "path",
         "name": "namespace",
@@ -10162,7 +14097,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10175,7 +14112,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind ServiceAccount",
       "nickname": "watchNamespacedServiceAccount",
@@ -10249,11 +14186,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -10269,7 +14210,7 @@
       "type": "v1.ServiceAccountList",
       "method": "GET",
       "summary": "list or watch objects of kind ServiceAccount",
-      "nickname": "listServiceAccount",
+      "nickname": "listServiceAccountForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -10328,7 +14269,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -10341,10 +14286,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of ServiceAccount",
-      "nickname": "watchServiceAccountList",
+      "nickname": "watchServiceAccountListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -10399,11 +14344,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -10486,7 +14435,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -10531,7 +14484,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10544,7 +14499,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Service",
       "nickname": "watchNamespacedServiceList",
@@ -10610,11 +14565,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -10637,6 +14596,22 @@
         "paramType": "query",
         "name": "pretty",
         "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "export",
+        "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "boolean",
+        "paramType": "query",
+        "name": "exact",
+        "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
         "required": false,
         "allowMultiple": false
        },
@@ -10665,7 +14640,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10718,7 +14695,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10771,7 +14750,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "application/json-patch+json",
@@ -10818,7 +14799,9 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
        "*/*"
@@ -10831,7 +14814,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch changes to an object of kind Service",
       "nickname": "watchNamespacedService",
@@ -10905,11 +14888,15 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -10918,14 +14905,14 @@
     ]
    },
    {
-    "path": "/api/v1/proxy/namespaces/{namespace}/services/{name}/{path:*}",
+    "path": "/api/v1/proxy/namespaces/{namespace}/services/{name}/{path}",
     "description": "API at /api/v1",
     "operations": [
      {
       "type": "string",
       "method": "GET",
       "summary": "proxy GET requests to Service",
-      "nickname": "proxyGETNamespacedService",
+      "nickname": "proxyGETNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -10963,7 +14950,7 @@
       "type": "string",
       "method": "PUT",
       "summary": "proxy PUT requests to Service",
-      "nickname": "proxyPUTNamespacedService",
+      "nickname": "proxyPUTNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -11001,7 +14988,7 @@
       "type": "string",
       "method": "POST",
       "summary": "proxy POST requests to Service",
-      "nickname": "proxyPOSTNamespacedService",
+      "nickname": "proxyPOSTNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -11039,7 +15026,7 @@
       "type": "string",
       "method": "DELETE",
       "summary": "proxy DELETE requests to Service",
-      "nickname": "proxyDELETENamespacedService",
+      "nickname": "proxyDELETENamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -11077,7 +15064,7 @@
       "type": "string",
       "method": "HEAD",
       "summary": "proxy HEAD requests to Service",
-      "nickname": "proxyHEADNamespacedService",
+      "nickname": "proxyHEADNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -11115,7 +15102,7 @@
       "type": "string",
       "method": "OPTIONS",
       "summary": "proxy OPTIONS requests to Service",
-      "nickname": "proxyOPTIONSNamespacedService",
+      "nickname": "proxyOPTIONSNamespacedServiceWithPath",
       "parameters": [
        {
         "type": "string",
@@ -11345,7 +15332,7 @@
       "type": "v1.ServiceList",
       "method": "GET",
       "summary": "list or watch objects of kind Service",
-      "nickname": "listService",
+      "nickname": "listServiceForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -11404,7 +15391,11 @@
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
@@ -11417,10 +15408,10 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "json.WatchEvent",
+      "type": "versioned.Event",
       "method": "GET",
       "summary": "watch individual changes to a list of Service",
-      "nickname": "watchServiceList",
+      "nickname": "watchServiceListForAllNamespaces",
       "parameters": [
        {
         "type": "string",
@@ -11475,14 +15466,699 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "json.WatchEvent"
+        "responseModel": "versioned.Event"
        }
       ],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf",
+       "application/json;stream=watch",
+       "application/vnd.kubernetes.protobuf;stream=watch"
       ],
       "consumes": [
        "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespace}/services/{name}/proxy",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "string",
+      "method": "GET",
+      "summary": "connect GET requests to proxy of Service",
+      "nickname": "connectGetNamespacedServiceProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to proxy of Service",
+      "nickname": "connectPostNamespacedServiceProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "PUT",
+      "summary": "connect PUT requests to proxy of Service",
+      "nickname": "connectPutNamespacedServiceProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "DELETE",
+      "summary": "connect DELETE requests to proxy of Service",
+      "nickname": "connectDeleteNamespacedServiceProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "HEAD",
+      "summary": "connect HEAD requests to proxy of Service",
+      "nickname": "connectHeadNamespacedServiceProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "OPTIONS",
+      "summary": "connect OPTIONS requests to proxy of Service",
+      "nickname": "connectOptionsNamespacedServiceProxy",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespace}/services/{name}/proxy/{path}",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "string",
+      "method": "GET",
+      "summary": "connect GET requests to proxy of Service",
+      "nickname": "connectGetNamespacedServiceProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "POST",
+      "summary": "connect POST requests to proxy of Service",
+      "nickname": "connectPostNamespacedServiceProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "PUT",
+      "summary": "connect PUT requests to proxy of Service",
+      "nickname": "connectPutNamespacedServiceProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "DELETE",
+      "summary": "connect DELETE requests to proxy of Service",
+      "nickname": "connectDeleteNamespacedServiceProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "HEAD",
+      "summary": "connect HEAD requests to proxy of Service",
+      "nickname": "connectHeadNamespacedServiceProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "string",
+      "method": "OPTIONS",
+      "summary": "connect OPTIONS requests to proxy of Service",
+      "nickname": "connectOptionsNamespacedServiceProxyWithPath",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "path",
+        "description": "Path is the part of URLs that include service endpoints, suffixes, and parameters to use for the current proxy request to service. For example, the whole request URL is http://localhost/api/v1/namespaces/kube-system/services/elasticsearch-logging/_search?q=user:kimchy. Path is _search?q=user:kimchy.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "path",
+        "description": "path to the resource",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "produces": [
+       "*/*"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
+    "path": "/api/v1/namespaces/{namespace}/services/{name}/status",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.Service",
+      "method": "GET",
+      "summary": "read status of the specified Service",
+      "nickname": "readNamespacedServiceStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Service"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Service",
+      "method": "PUT",
+      "summary": "replace status of the specified Service",
+      "nickname": "replaceNamespacedServiceStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.Service",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Service"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     },
+     {
+      "type": "v1.Service",
+      "method": "PATCH",
+      "summary": "partially update status of the specified Service",
+      "nickname": "patchNamespacedServiceStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "unversioned.Patch",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the Service",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.Service"
+       }
+      ],
+      "produces": [
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
+      ],
+      "consumes": [
+       "application/json-patch+json",
+       "application/merge-patch+json",
+       "application/strategic-merge-patch+json"
       ]
      }
     ]
@@ -11492,16 +16168,20 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "void",
+      "type": "unversioned.APIResourceList",
       "method": "GET",
       "summary": "get available resources",
       "nickname": "getAPIResources",
       "parameters": [],
       "produces": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ],
       "consumes": [
-       "application/json"
+       "application/json",
+       "application/yaml",
+       "application/vnd.kubernetes.protobuf"
       ]
      }
     ]
@@ -11539,7 +16219,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
+      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
      },
      "generateName": {
       "type": "string",
@@ -11547,7 +16227,7 @@
      },
      "namespace": {
       "type": "string",
-      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
+      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
      },
      "selfLink": {
       "type": "string",
@@ -11555,7 +16235,7 @@
      },
      "uid": {
       "type": "string",
-      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#uids"
+      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
      },
      "resourceVersion": {
       "type": "string",
@@ -11564,15 +16244,17 @@
      "generation": {
       "type": "integer",
       "format": "int64",
-      "description": "A sequence number representing a specific generation of the desired state. Currently only implemented by replication controllers. Populated by the system. Read-only."
+      "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only."
      },
      "creationTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
-      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+      "format": "date-time",
+      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
       "type": "integer",
@@ -11580,12 +16262,62 @@
       "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only."
      },
      "labels": {
-      "type": "any",
-      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md"
+      "type": "object",
+      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels"
      },
      "annotations": {
-      "type": "any",
-      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/HEAD/docs/user-guide/annotations.md"
+      "type": "object",
+      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations"
+     },
+     "ownerReferences": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.OwnerReference"
+      },
+      "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller."
+     },
+     "finalizers": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed."
+     },
+     "clusterName": {
+      "type": "string",
+      "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request."
+     }
+    }
+   },
+   "v1.OwnerReference": {
+    "id": "v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
      }
     }
    },
@@ -11599,15 +16331,15 @@
      },
      "namespace": {
       "type": "string",
-      "description": "Namespace of the referent. More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
+      "description": "Namespace of the referent. More info: http://kubernetes.io/docs/user-guide/namespaces"
      },
      "name": {
       "type": "string",
-      "description": "Name of the referent. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
      },
      "uid": {
       "type": "string",
-      "description": "UID of the referent. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#uids"
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
      },
      "apiVersion": {
       "type": "string",
@@ -11716,6 +16448,204 @@
      }
     }
    },
+   "v1.ConfigMapList": {
+    "id": "v1.ConfigMapList",
+    "description": "ConfigMapList is a resource containing a list of ConfigMap objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "unversioned.ListMeta",
+      "description": "More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ConfigMap"
+      },
+      "description": "Items is the list of ConfigMaps."
+     }
+    }
+   },
+   "v1.ConfigMap": {
+    "id": "v1.ConfigMap",
+    "description": "ConfigMap holds configuration data for pods to consume.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "data": {
+      "type": "object",
+      "description": "Data contains the configuration data. Each key must be a valid DNS_SUBDOMAIN with an optional leading dot."
+     }
+    }
+   },
+   "unversioned.Status": {
+    "id": "unversioned.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "unversioned.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "unversioned.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "unversioned.StatusDetails": {
+    "id": "unversioned.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "unversioned.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "unversioned.StatusCause": {
+    "id": "unversioned.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "versioned.Event": {
+    "id": "versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "unversioned.Patch": {
+    "id": "unversioned.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "v1.DeleteOptions": {
+    "id": "v1.DeleteOptions",
+    "description": "DeleteOptions may be provided when deleting an API object",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "gracePeriodSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately."
+     },
+     "preconditions": {
+      "$ref": "v1.Preconditions",
+      "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned."
+     },
+     "orphanDependents": {
+      "type": "boolean",
+      "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list."
+     }
+    }
+   },
+   "v1.Preconditions": {
+    "id": "v1.Preconditions",
+    "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+    "properties": {
+     "uid": {
+      "$ref": "types.UID",
+      "description": "Specifies the target UID."
+     }
+    }
+   },
+   "types.UID": {
+    "id": "types.UID",
+    "properties": {}
+   },
    "v1.EndpointsList": {
     "id": "v1.EndpointsList",
     "description": "EndpointsList is a list of endpoints.",
@@ -11808,7 +16738,15 @@
     "properties": {
      "ip": {
       "type": "string",
-      "description": "The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24)."
+      "description": "The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready."
+     },
+     "hostname": {
+      "type": "string",
+      "description": "The Hostname of this endpoint"
+     },
+     "nodeName": {
+      "type": "string",
+      "description": "Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node."
      },
      "targetRef": {
       "$ref": "v1.ObjectReference",
@@ -11835,129 +16773,6 @@
      "protocol": {
       "type": "string",
       "description": "The IP protocol for this port. Must be UDP or TCP. Default is TCP."
-     }
-    }
-   },
-   "json.WatchEvent": {
-    "id": "json.WatchEvent",
-    "properties": {
-     "type": {
-      "type": "string",
-      "description": "the type of watch event; may be ADDED, MODIFIED, DELETED, or ERROR"
-     },
-     "object": {
-      "type": "string",
-      "description": "the object being watched; will match the type of the resource endpoint or be a Status object if the type is ERROR"
-     }
-    }
-   },
-   "unversioned.Patch": {
-    "id": "unversioned.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
-    "properties": {}
-   },
-   "unversioned.Status": {
-    "id": "unversioned.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
-    "properties": {
-     "kind": {
-      "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
-     },
-     "apiVersion": {
-      "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
-     },
-     "metadata": {
-      "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
-     },
-     "status": {
-      "type": "string",
-      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
-     },
-     "message": {
-      "type": "string",
-      "description": "A human-readable description of the status of this operation."
-     },
-     "reason": {
-      "type": "string",
-      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
-     },
-     "details": {
-      "$ref": "unversioned.StatusDetails",
-      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
-     },
-     "code": {
-      "type": "integer",
-      "format": "int32",
-      "description": "Suggested HTTP return code for this status, 0 if not set."
-     }
-    }
-   },
-   "unversioned.StatusDetails": {
-    "id": "unversioned.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
-    "properties": {
-     "name": {
-      "type": "string",
-      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
-     },
-     "kind": {
-      "type": "string",
-      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
-     },
-     "causes": {
-      "type": "array",
-      "items": {
-       "$ref": "unversioned.StatusCause"
-      },
-      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
-     },
-     "retryAfterSeconds": {
-      "type": "integer",
-      "format": "int32",
-      "description": "If specified, the time in seconds before the operation should be retried."
-     }
-    }
-   },
-   "unversioned.StatusCause": {
-    "id": "unversioned.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
-    "properties": {
-     "reason": {
-      "type": "string",
-      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
-     },
-     "message": {
-      "type": "string",
-      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
-     },
-     "field": {
-      "type": "string",
-      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
-     }
-    }
-   },
-   "v1.DeleteOptions": {
-    "id": "v1.DeleteOptions",
-    "description": "DeleteOptions may be provided when deleting an API object",
-    "required": [
-     "gracePeriodSeconds"
-    ],
-    "properties": {
-     "kind": {
-      "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
-     },
-     "apiVersion": {
-      "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
-     },
-     "gracePeriodSeconds": {
-      "type": "integer",
-      "format": "int64",
-      "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately."
      }
     }
    },
@@ -12027,16 +16842,22 @@
      },
      "firstTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)"
      },
      "lastTimestamp": {
       "type": "string",
+      "format": "date-time",
       "description": "The time at which the most recent occurrence of this event was recorded."
      },
      "count": {
       "type": "integer",
       "format": "int32",
       "description": "The number of times this event has occurred."
+     },
+     "type": {
+      "type": "string",
+      "description": "Type of this event (Normal, Warning), new types could be added in the future"
      }
     }
    },
@@ -12050,7 +16871,7 @@
      },
      "host": {
       "type": "string",
-      "description": "Host name on which the event is generated."
+      "description": "Node name on which the event is generated."
      }
     }
    },
@@ -12129,23 +16950,23 @@
       "description": "Type of resource that this limit applies to."
      },
      "max": {
-      "type": "any",
+      "type": "object",
       "description": "Max usage constraints on this kind by resource name."
      },
      "min": {
-      "type": "any",
+      "type": "object",
       "description": "Min usage constraints on this kind by resource name."
      },
      "default": {
-      "type": "any",
+      "type": "object",
       "description": "Default resource requirement limit value by resource name if resource limit is omitted."
      },
      "defaultRequest": {
-      "type": "any",
+      "type": "object",
       "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted."
      },
      "maxLimitRequestRatio": {
-      "type": "any",
+      "type": "object",
       "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource."
      }
     }
@@ -12174,7 +16995,7 @@
       "items": {
        "$ref": "v1.Namespace"
       },
-      "description": "Items is the list of Namespace objects in the list. More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
+      "description": "Items is the list of Namespace objects in the list. More info: http://kubernetes.io/docs/user-guide/namespaces"
      }
     }
    },
@@ -12261,7 +17082,7 @@
    },
    "v1.Node": {
     "id": "v1.Node",
-    "description": "Node is a worker node in Kubernetes, formerly known as minion. Each node will have a unique identifier in the cache (i.e. in etcd).",
+    "description": "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).",
     "properties": {
      "kind": {
       "type": "string",
@@ -12303,7 +17124,7 @@
      },
      "unschedulable": {
       "type": "boolean",
-      "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#manual-node-administration\"`"
+      "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#manual-node-administration\""
      }
     }
    },
@@ -12312,12 +17133,16 @@
     "description": "NodeStatus is information about the current status of a node.",
     "properties": {
      "capacity": {
-      "type": "any",
-      "description": "Capacity represents the available resources of a node. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity for more details."
+      "type": "object",
+      "description": "Capacity represents the total resources of a node. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity for more details."
+     },
+     "allocatable": {
+      "type": "object",
+      "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity."
      },
      "phase": {
       "type": "string",
-      "description": "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase"
+      "description": "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-phase The field is never populated, and now is deprecated."
      },
      "conditions": {
       "type": "array",
@@ -12340,12 +17165,33 @@
      "nodeInfo": {
       "$ref": "v1.NodeSystemInfo",
       "description": "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-info"
+     },
+     "images": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ContainerImage"
+      },
+      "description": "List of container images on this node"
+     },
+     "volumesInUse": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.UniqueVolumeName"
+      },
+      "description": "List of attachable volumes in use (mounted) by the node."
+     },
+     "volumesAttached": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.AttachedVolume"
+      },
+      "description": "List of volumes that are attached to the node."
      }
     }
    },
    "v1.NodeCondition": {
     "id": "v1.NodeCondition",
-    "description": "NodeCondition contains condition infromation for a node.",
+    "description": "NodeCondition contains condition information for a node.",
     "required": [
      "type",
      "status"
@@ -12353,7 +17199,7 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type of node condition, currently only Ready."
+      "description": "Type of node condition."
      },
      "status": {
       "type": "string",
@@ -12361,10 +17207,12 @@
      },
      "lastHeartbeatTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time we got an update on a given condition."
      },
      "lastTransitionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition transit from one status to another."
      },
      "reason": {
@@ -12430,16 +17278,18 @@
      "osImage",
      "containerRuntimeVersion",
      "kubeletVersion",
-     "kubeProxyVersion"
+     "kubeProxyVersion",
+     "operatingSystem",
+     "architecture"
     ],
     "properties": {
      "machineID": {
       "type": "string",
-      "description": "Machine ID reported by the node."
+      "description": "MachineID reported by the node. For unique machine identification in the cluster this field is prefered. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html"
      },
      "systemUUID": {
       "type": "string",
-      "description": "System UUID reported by the node."
+      "description": "SystemUUID reported by the node. For unique machine identification MachineID is prefered. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-US/Red_Hat_Subscription_Management/1/html/RHSM/getting-system-uuid.html"
      },
      "bootID": {
       "type": "string",
@@ -12464,6 +17314,57 @@
      "kubeProxyVersion": {
       "type": "string",
       "description": "KubeProxy Version reported by the node."
+     },
+     "operatingSystem": {
+      "type": "string",
+      "description": "The Operating System reported by the node"
+     },
+     "architecture": {
+      "type": "string",
+      "description": "The Architecture reported by the node"
+     }
+    }
+   },
+   "v1.ContainerImage": {
+    "id": "v1.ContainerImage",
+    "description": "Describe a container image",
+    "required": [
+     "names"
+    ],
+    "properties": {
+     "names": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Names by which this image is known. e.g. [\"gcr.io/google_containers/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]"
+     },
+     "sizeBytes": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The size of the image in bytes."
+     }
+    }
+   },
+   "v1.UniqueVolumeName": {
+    "id": "v1.UniqueVolumeName",
+    "properties": {}
+   },
+   "v1.AttachedVolume": {
+    "id": "v1.AttachedVolume",
+    "description": "AttachedVolume describes a volume attached to a node",
+    "required": [
+     "name",
+     "devicePath"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "Name of the attached volume"
+     },
+     "devicePath": {
+      "type": "string",
+      "description": "DevicePath represents the device path where the volume should be available"
      }
     }
    },
@@ -12491,7 +17392,7 @@
       "items": {
        "$ref": "v1.PersistentVolumeClaim"
       },
-      "description": "A list of persistent volume claims. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "A list of persistent volume claims. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
      }
     }
    },
@@ -12513,11 +17414,11 @@
      },
      "spec": {
       "$ref": "v1.PersistentVolumeClaimSpec",
-      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
      },
      "status": {
       "$ref": "v1.PersistentVolumeClaimStatus",
-      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
      }
     }
    },
@@ -12530,11 +17431,15 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "AccessModes contains the desired access modes the volume should have. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes-1"
+      "description": "AccessModes contains the desired access modes the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes-1"
+     },
+     "selector": {
+      "$ref": "unversioned.LabelSelector",
+      "description": "A label query over volumes to consider for binding."
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Resources represents the minimum resources the volume should have. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#resources"
+      "description": "Resources represents the minimum resources the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources"
      },
      "volumeName": {
       "type": "string",
@@ -12546,17 +17451,59 @@
     "id": "v1.PersistentVolumeAccessMode",
     "properties": {}
    },
+   "unversioned.LabelSelector": {
+    "id": "unversioned.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "unversioned.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "unversioned.LabelSelectorRequirement": {
+    "id": "unversioned.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
    "v1.ResourceRequirements": {
     "id": "v1.ResourceRequirements",
     "description": "ResourceRequirements describes the compute resource requirements.",
     "properties": {
      "limits": {
-      "type": "any",
-      "description": "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/HEAD/docs/design/resources.md#resource-specifications"
+      "type": "object",
+      "description": "Limits describes the maximum amount of compute resources allowed. More info: http://kubernetes.io/docs/user-guide/compute-resources/"
      },
      "requests": {
-      "type": "any",
-      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/HEAD/docs/design/resources.md#resource-specifications"
+      "type": "object",
+      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://kubernetes.io/docs/user-guide/compute-resources/"
      }
     }
    },
@@ -12573,10 +17520,10 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes-1"
+      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes-1"
      },
      "capacity": {
-      "type": "any",
+      "type": "object",
       "description": "Represents the actual resources of the underlying volume."
      }
     }
@@ -12605,13 +17552,13 @@
       "items": {
        "$ref": "v1.PersistentVolume"
       },
-      "description": "List of persistent volumes. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md"
+      "description": "List of persistent volumes. More info: http://kubernetes.io/docs/user-guide/persistent-volumes"
      }
     }
    },
    "v1.PersistentVolume": {
     "id": "v1.PersistentVolume",
-    "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md",
+    "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://kubernetes.io/docs/user-guide/persistent-volumes",
     "properties": {
      "kind": {
       "type": "string",
@@ -12627,11 +17574,11 @@
      },
      "spec": {
       "$ref": "v1.PersistentVolumeSpec",
-      "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistent-volumes"
+      "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistent-volumes"
      },
      "status": {
       "$ref": "v1.PersistentVolumeStatus",
-      "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistent-volumes"
+      "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistent-volumes"
      }
     }
    },
@@ -12640,32 +17587,32 @@
     "description": "PersistentVolumeSpec is the specification of a persistent volume.",
     "properties": {
      "capacity": {
-      "type": "any",
-      "description": "A description of the persistent volume's resources and capacity. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#capacity"
+      "type": "object",
+      "description": "A description of the persistent volume's resources and capacity. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"
+      "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://kubernetes.io/docs/user-guide/volumes#hostpath"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md"
+      "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
+      "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md"
+      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
@@ -12687,65 +17634,87 @@
       "$ref": "v1.FlockerVolumeSource",
       "description": "Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running"
      },
+     "flexVolume": {
+      "$ref": "v1.FlexVolumeSource",
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future."
+     },
+     "azureFile": {
+      "$ref": "v1.AzureFileVolumeSource",
+      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod."
+     },
+     "vsphereVolume": {
+      "$ref": "v1.VsphereVirtualDiskVolumeSource",
+      "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine"
+     },
+     "quobyte": {
+      "$ref": "v1.QuobyteVolumeSource",
+      "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime"
+     },
+     "azureDisk": {
+      "$ref": "v1.AzureDiskVolumeSource",
+      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod."
+     },
+     "photonPersistentDisk": {
+      "$ref": "v1.PhotonPersistentDiskVolumeSource",
+      "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine"
+     },
      "accessModes": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "AccessModes contains all ways the volume can be mounted. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#access-modes"
+      "description": "AccessModes contains all ways the volume can be mounted. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes"
      },
      "claimRef": {
       "$ref": "v1.ObjectReference",
-      "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#binding"
+      "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#binding"
      },
      "persistentVolumeReclaimPolicy": {
       "type": "string",
-      "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#recycling-policy"
+      "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recycling must be supported by the volume plugin underlying this persistent volume. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#recycling-policy"
      }
     }
    },
    "v1.GCEPersistentDiskVolumeSource": {
     "id": "v1.GCEPersistentDiskVolumeSource",
-    "description": "GCEPersistentDiskVolumeSource represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist and be formatted before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once.",
+    "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
     "required": [
-     "pdName",
-     "fsType"
+     "pdName"
     ],
     "properties": {
      "pdName": {
       "type": "string",
-      "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
      }
     }
    },
    "v1.AWSElasticBlockStoreVolumeSource": {
     "id": "v1.AWSElasticBlockStoreVolumeSource",
-    "description": "Represents a persistent disk resource in AWS.\n\nAn Amazon Elastic Block Store (EBS) must already be created, formatted, and reside in the same AWS zone as the kubelet before it can be mounted. Note: Amazon EBS volumes can be mounted to only one instance at a time.",
+    "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
     "required": [
-     "volumeID",
-     "fsType"
+     "volumeID"
     ],
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
      },
      "partition": {
       "type": "integer",
@@ -12754,26 +17723,26 @@
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
      }
     }
    },
    "v1.HostPathVolumeSource": {
     "id": "v1.HostPathVolumeSource",
-    "description": "HostPathVolumeSource represents bare host directory volume.",
+    "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
     "required": [
      "path"
     ],
     "properties": {
      "path": {
       "type": "string",
-      "description": "Path of the directory on the host. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"
+      "description": "Path of the directory on the host. More info: http://kubernetes.io/docs/user-guide/volumes#hostpath"
      }
     }
    },
    "v1.GlusterfsVolumeSource": {
     "id": "v1.GlusterfsVolumeSource",
-    "description": "GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod.",
+    "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
     "required": [
      "endpoints",
      "path"
@@ -12781,21 +17750,21 @@
     "properties": {
      "endpoints": {
       "type": "string",
-      "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod"
+      "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod"
      },
      "path": {
       "type": "string",
-      "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod"
+      "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md#create-a-pod"
+      "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod"
      }
     }
    },
    "v1.NFSVolumeSource": {
     "id": "v1.NFSVolumeSource",
-    "description": "NFSVolumeSource represents an NFS mount that lasts the lifetime of a pod",
+    "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
     "required": [
      "server",
      "path"
@@ -12803,28 +17772,24 @@
     "properties": {
      "server": {
       "type": "string",
-      "description": "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
+      "description": "Server is the hostname or IP address of the NFS server. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
      },
      "path": {
       "type": "string",
-      "description": "Path that is exported by the NFS server. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
+      "description": "Path that is exported by the NFS server. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
+      "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
      }
     }
    },
    "v1.RBDVolumeSource": {
     "id": "v1.RBDVolumeSource",
-    "description": "RBDVolumeSource represents a Rados Block Device Mount that lasts the lifetime of a pod",
+    "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
     "required": [
      "monitors",
-     "image",
-     "pool",
-     "user",
-     "keyring",
-     "secretRef"
+     "image"
     ],
     "properties": {
      "monitors": {
@@ -12832,35 +17797,35 @@
       "items": {
        "type": "string"
       },
-      "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it"
+      "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
      },
      "image": {
       "type": "string",
-      "description": "The rados image name. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it"
+      "description": "The rados image name. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#rbd"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#rbd"
      },
      "pool": {
       "type": "string",
-      "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it."
+      "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it."
      },
      "user": {
       "type": "string",
-      "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it"
+      "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
      },
      "keyring": {
       "type": "string",
-      "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it"
+      "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it"
+      "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md#how-to-use-it"
+      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
      }
     }
    },
@@ -12870,18 +17835,17 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the referent. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
      }
     }
    },
    "v1.ISCSIVolumeSource": {
     "id": "v1.ISCSIVolumeSource",
-    "description": "ISCSIVolumeSource describes an ISCSI Disk can only be mounted as read/write once.",
+    "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
     "required": [
      "targetPortal",
      "iqn",
-     "lun",
-     "fsType"
+     "lun"
     ],
     "properties": {
      "targetPortal": {
@@ -12897,9 +17861,13 @@
       "format": "int32",
       "description": "iSCSI target lun number."
      },
+     "iscsiInterface": {
+      "type": "string",
+      "description": "Optional: Defaults to 'default' (tcp). iSCSI interface name that uses an iSCSI transport."
+     },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#iscsi"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#iscsi"
      },
      "readOnly": {
       "type": "boolean",
@@ -12909,7 +17877,7 @@
    },
    "v1.CinderVolumeSource": {
     "id": "v1.CinderVolumeSource",
-    "description": "CinderVolumeSource represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet.",
+    "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
     "required": [
      "volumeID"
     ],
@@ -12920,7 +17888,7 @@
      },
      "fsType": {
       "type": "string",
-      "description": "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+      "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
      },
      "readOnly": {
       "type": "boolean",
@@ -12930,7 +17898,7 @@
    },
    "v1.CephFSVolumeSource": {
     "id": "v1.CephFSVolumeSource",
-    "description": "CephFSVolumeSource represents a Ceph Filesystem Mount that lasts the lifetime of a pod",
+    "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
     "required": [
      "monitors"
     ],
@@ -12940,33 +17908,36 @@
       "items": {
        "type": "string"
       },
-      "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/HEAD/examples/cephfs/README.md#how-to-use-it"
+      "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+     },
+     "path": {
+      "type": "string",
+      "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /"
      },
      "user": {
       "type": "string",
-      "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/HEAD/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
      },
      "secretFile": {
       "type": "string",
-      "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/HEAD/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/HEAD/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/HEAD/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
      }
     }
    },
    "v1.FCVolumeSource": {
     "id": "v1.FCVolumeSource",
-    "description": "A Fibre Channel Disk can only be mounted as read/write once.",
+    "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
     "required": [
      "targetWWNs",
-     "lun",
-     "fsType"
+     "lun"
     ],
     "properties": {
      "targetWWNs": {
@@ -12974,7 +17945,7 @@
       "items": {
        "type": "string"
       },
-      "description": "Required: FC target world wide names (WWNs)"
+      "description": "Required: FC target worldwide names (WWNs)"
      },
      "lun": {
       "type": "integer",
@@ -12983,7 +17954,7 @@
      },
      "fsType": {
       "type": "string",
-      "description": "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\""
+      "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
      },
      "readOnly": {
       "type": "boolean",
@@ -12993,14 +17964,164 @@
    },
    "v1.FlockerVolumeSource": {
     "id": "v1.FlockerVolumeSource",
-    "description": "FlockerVolumeSource represents a Flocker volume mounted by the Flocker agent.",
-    "required": [
-     "datasetName"
-    ],
+    "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
     "properties": {
      "datasetName": {
       "type": "string",
-      "description": "Required: the volume name. This is going to be store on metadata -\u003e name on the payload for Flocker"
+      "description": "Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated"
+     },
+     "datasetUUID": {
+      "type": "string",
+      "description": "UUID of the dataset. This is unique identifier of a Flocker dataset"
+     }
+    }
+   },
+   "v1.FlexVolumeSource": {
+    "id": "v1.FlexVolumeSource",
+    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
+    "required": [
+     "driver"
+    ],
+    "properties": {
+     "driver": {
+      "type": "string",
+      "description": "Driver is the name of the driver to use for this volume."
+     },
+     "fsType": {
+      "type": "string",
+      "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script."
+     },
+     "secretRef": {
+      "$ref": "v1.LocalObjectReference",
+      "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+     },
+     "options": {
+      "type": "object",
+      "description": "Optional: Extra command options if any."
+     }
+    }
+   },
+   "v1.AzureFileVolumeSource": {
+    "id": "v1.AzureFileVolumeSource",
+    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+    "required": [
+     "secretName",
+     "shareName"
+    ],
+    "properties": {
+     "secretName": {
+      "type": "string",
+      "description": "the name of secret that contains Azure Storage Account Name and Key"
+     },
+     "shareName": {
+      "type": "string",
+      "description": "Share Name"
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+     }
+    }
+   },
+   "v1.VsphereVirtualDiskVolumeSource": {
+    "id": "v1.VsphereVirtualDiskVolumeSource",
+    "description": "Represents a vSphere volume resource.",
+    "required": [
+     "volumePath"
+    ],
+    "properties": {
+     "volumePath": {
+      "type": "string",
+      "description": "Path that identifies vSphere volume vmdk"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
+     }
+    }
+   },
+   "v1.QuobyteVolumeSource": {
+    "id": "v1.QuobyteVolumeSource",
+    "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+    "required": [
+     "registry",
+     "volume"
+    ],
+    "properties": {
+     "registry": {
+      "type": "string",
+      "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes"
+     },
+     "volume": {
+      "type": "string",
+      "description": "Volume is a string that references an already created Quobyte volume by name."
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false."
+     },
+     "user": {
+      "type": "string",
+      "description": "User to map volume access to Defaults to serivceaccount user"
+     },
+     "group": {
+      "type": "string",
+      "description": "Group to map volume access to Default is no group"
+     }
+    }
+   },
+   "v1.AzureDiskVolumeSource": {
+    "id": "v1.AzureDiskVolumeSource",
+    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+    "required": [
+     "diskName",
+     "diskURI"
+    ],
+    "properties": {
+     "diskName": {
+      "type": "string",
+      "description": "The Name of the data disk in the blob storage"
+     },
+     "diskURI": {
+      "type": "string",
+      "description": "The URI the data disk in the blob storage"
+     },
+     "cachingMode": {
+      "$ref": "v1.AzureDataDiskCachingMode",
+      "description": "Host Caching mode: None, Read Only, Read Write."
+     },
+     "fsType": {
+      "type": "string",
+      "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
+     },
+     "readOnly": {
+      "type": "boolean",
+      "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+     }
+    }
+   },
+   "v1.AzureDataDiskCachingMode": {
+    "id": "v1.AzureDataDiskCachingMode",
+    "properties": {}
+   },
+   "v1.PhotonPersistentDiskVolumeSource": {
+    "id": "v1.PhotonPersistentDiskVolumeSource",
+    "description": "Represents a Photon Controller persistent disk resource.",
+    "required": [
+     "pdID"
+    ],
+    "properties": {
+     "pdID": {
+      "type": "string",
+      "description": "ID that identifies Photon Controller persistent disk"
+     },
+     "fsType": {
+      "type": "string",
+      "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
      }
     }
    },
@@ -13010,7 +18131,7 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#phase"
+      "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#phase"
      },
      "message": {
       "type": "string",
@@ -13046,7 +18167,7 @@
       "items": {
        "$ref": "v1.Pod"
       },
-      "description": "List of pods. More info: http://releases.k8s.io/HEAD/docs/user-guide/pods.md"
+      "description": "List of pods. More info: http://kubernetes.io/docs/user-guide/pods"
      }
     }
    },
@@ -13088,18 +18209,18 @@
       "items": {
        "$ref": "v1.Volume"
       },
-      "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md"
+      "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes"
      },
      "containers": {
       "type": "array",
       "items": {
        "$ref": "v1.Container"
       },
-      "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/containers.md"
+      "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers"
      },
      "restartPolicy": {
       "type": "string",
-      "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#restartpolicy"
+      "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://kubernetes.io/docs/user-guide/pod-states#restartpolicy"
      },
      "terminationGracePeriodSeconds": {
       "type": "integer",
@@ -13116,8 +18237,8 @@
       "description": "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\"."
      },
      "nodeSelector": {
-      "type": "any",
-      "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/HEAD/docs/user-guide/node-selection/README.md"
+      "type": "object",
+      "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://kubernetes.io/docs/user-guide/node-selection/README"
      },
      "serviceAccountName": {
       "type": "string",
@@ -13152,7 +18273,15 @@
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
+      "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod"
+     },
+     "hostname": {
+      "type": "string",
+      "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value."
+     },
+     "subdomain": {
+      "type": "string",
+      "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all."
      }
     }
    },
@@ -13165,23 +18294,23 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"
+      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#hostpath"
+      "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://kubernetes.io/docs/user-guide/volumes#hostpath"
      },
      "emptyDir": {
       "$ref": "v1.EmptyDirVolumeSource",
-      "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"
+      "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
      },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
@@ -13189,27 +18318,31 @@
      },
      "secret": {
       "$ref": "v1.SecretVolumeSource",
-      "description": "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#secrets"
+      "description": "Secret represents a secret that should populate this volume. More info: http://kubernetes.io/docs/user-guide/volumes#secrets"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#nfs"
+      "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
-      "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/examples/iscsi/README.md"
+      "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/glusterfs/README.md"
+      "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md"
      },
      "persistentVolumeClaim": {
       "$ref": "v1.PersistentVolumeClaimVolumeSource",
-      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/rbd/README.md"
+      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md"
+     },
+     "flexVolume": {
+      "$ref": "v1.FlexVolumeSource",
+      "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future."
      },
      "cinder": {
       "$ref": "v1.CinderVolumeSource",
@@ -13230,25 +18363,48 @@
      "fc": {
       "$ref": "v1.FCVolumeSource",
       "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
+     },
+     "azureFile": {
+      "$ref": "v1.AzureFileVolumeSource",
+      "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod."
+     },
+     "configMap": {
+      "$ref": "v1.ConfigMapVolumeSource",
+      "description": "ConfigMap represents a configMap that should populate this volume"
+     },
+     "vsphereVolume": {
+      "$ref": "v1.VsphereVirtualDiskVolumeSource",
+      "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine"
+     },
+     "quobyte": {
+      "$ref": "v1.QuobyteVolumeSource",
+      "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime"
+     },
+     "azureDisk": {
+      "$ref": "v1.AzureDiskVolumeSource",
+      "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod."
+     },
+     "photonPersistentDisk": {
+      "$ref": "v1.PhotonPersistentDiskVolumeSource",
+      "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine"
      }
     }
    },
    "v1.EmptyDirVolumeSource": {
     "id": "v1.EmptyDirVolumeSource",
-    "description": "EmptyDirVolumeSource is temporary directory that shares a pod's lifetime.",
+    "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
     "properties": {
      "medium": {
       "type": "string",
-      "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#emptydir"
+      "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
      }
     }
    },
    "v1.GitRepoVolumeSource": {
     "id": "v1.GitRepoVolumeSource",
-    "description": "GitRepoVolumeSource represents a volume that is pulled from git when the pod is created.",
+    "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.",
     "required": [
-     "repository",
-     "revision"
+     "repository"
     ],
     "properties": {
      "repository": {
@@ -13258,19 +18414,55 @@
      "revision": {
       "type": "string",
       "description": "Commit hash for the specified revision."
+     },
+     "directory": {
+      "type": "string",
+      "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name."
      }
     }
    },
    "v1.SecretVolumeSource": {
     "id": "v1.SecretVolumeSource",
-    "description": "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/HEAD/docs/design/secrets.md",
-    "required": [
-     "secretName"
-    ],
+    "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
     "properties": {
      "secretName": {
       "type": "string",
-      "description": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/HEAD/docs/user-guide/volumes.md#secrets"
+      "description": "Name of the secret in the pod's namespace to use. More info: http://kubernetes.io/docs/user-guide/volumes#secrets"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.KeyToPath"
+      },
+      "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'."
+     },
+     "defaultMode": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+     }
+    }
+   },
+   "v1.KeyToPath": {
+    "id": "v1.KeyToPath",
+    "description": "Maps a string key to a path within a volume.",
+    "required": [
+     "key",
+     "path"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "The key to project."
+     },
+     "path": {
+      "type": "string",
+      "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'."
+     },
+     "mode": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },
@@ -13283,7 +18475,7 @@
     "properties": {
      "claimName": {
       "type": "string",
-      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
      },
      "readOnly": {
       "type": "boolean",
@@ -13293,7 +18485,7 @@
    },
    "v1.DownwardAPIVolumeSource": {
     "id": "v1.DownwardAPIVolumeSource",
-    "description": "DownwardAPIVolumeSource represents a volume containing downward API info",
+    "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
     "properties": {
      "items": {
       "type": "array",
@@ -13301,6 +18493,11 @@
        "$ref": "v1.DownwardAPIVolumeFile"
       },
       "description": "Items is a list of downward API volume file"
+     },
+     "defaultMode": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },
@@ -13308,8 +18505,7 @@
     "id": "v1.DownwardAPIVolumeFile",
     "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
     "required": [
-     "path",
-     "fieldRef"
+     "path"
     ],
     "properties": {
      "path": {
@@ -13319,6 +18515,15 @@
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
       "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+     },
+     "resourceFieldRef": {
+      "$ref": "v1.ResourceFieldSelector",
+      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+     },
+     "mode": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },
@@ -13339,6 +18544,49 @@
      }
     }
    },
+   "v1.ResourceFieldSelector": {
+    "id": "v1.ResourceFieldSelector",
+    "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+    "required": [
+     "resource"
+    ],
+    "properties": {
+     "containerName": {
+      "type": "string",
+      "description": "Container name: required for volumes, optional for env vars"
+     },
+     "resource": {
+      "type": "string",
+      "description": "Required: resource to select"
+     },
+     "divisor": {
+      "type": "string",
+      "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+     }
+    }
+   },
+   "v1.ConfigMapVolumeSource": {
+    "id": "v1.ConfigMapVolumeSource",
+    "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.KeyToPath"
+      },
+      "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'."
+     },
+     "defaultMode": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+     }
+    }
+   },
    "v1.Container": {
     "id": "v1.Container",
     "description": "A single application container that you want to run within a pod.",
@@ -13352,32 +18600,32 @@
      },
      "image": {
       "type": "string",
-      "description": "Docker image name. More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md"
+      "description": "Docker image name. More info: http://kubernetes.io/docs/user-guide/images"
      },
      "command": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands"
+      "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers#containers-and-commands"
      },
      "args": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/containers.md#containers-and-commands"
+      "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers#containers-and-commands"
      },
      "workingDir": {
       "type": "string",
-      "description": "Container's working directory. Defaults to Docker's default. D efaults to image's default. Cannot be updated."
+      "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated."
      },
      "ports": {
       "type": "array",
       "items": {
        "$ref": "v1.ContainerPort"
       },
-      "description": "List of ports to expose from the container. Cannot be updated."
+      "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -13388,22 +18636,22 @@
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/persistent-volumes.md#resources"
+      "description": "Compute Resources required by this container. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources"
      },
      "volumeMounts": {
       "type": "array",
       "items": {
        "$ref": "v1.VolumeMount"
       },
-      "description": "Pod volumes to mount into the container's filesyste. Cannot be updated."
+      "description": "Pod volumes to mount into the container's filesystem. Cannot be updated."
      },
      "livenessProbe": {
       "$ref": "v1.Probe",
-      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
+      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
      },
      "readinessProbe": {
       "$ref": "v1.Probe",
-      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
+      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
      },
      "lifecycle": {
       "$ref": "v1.Lifecycle",
@@ -13415,7 +18663,7 @@
      },
      "imagePullPolicy": {
       "type": "string",
-      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md#updating-images"
+      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/images#updating-images"
      },
      "securityContext": {
       "$ref": "v1.SecurityContext",
@@ -13490,13 +18738,56 @@
    "v1.EnvVarSource": {
     "id": "v1.EnvVarSource",
     "description": "EnvVarSource represents a source for the value of an EnvVar.",
-    "required": [
-     "fieldRef"
-    ],
     "properties": {
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Selects a field of the pod. Only name and namespace are supported."
+      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP."
+     },
+     "resourceFieldRef": {
+      "$ref": "v1.ResourceFieldSelector",
+      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+     },
+     "configMapKeyRef": {
+      "$ref": "v1.ConfigMapKeySelector",
+      "description": "Selects a key of a ConfigMap."
+     },
+     "secretKeyRef": {
+      "$ref": "v1.SecretKeySelector",
+      "description": "Selects a key of a secret in the pod's namespace"
+     }
+    }
+   },
+   "v1.ConfigMapKeySelector": {
+    "id": "v1.ConfigMapKeySelector",
+    "description": "Selects a key from a ConfigMap.",
+    "required": [
+     "key"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "key": {
+      "type": "string",
+      "description": "The key to select."
+     }
+    }
+   },
+   "v1.SecretKeySelector": {
+    "id": "v1.SecretKeySelector",
+    "description": "SecretKeySelector selects a key of a Secret.",
+    "required": [
+     "key"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "key": {
+      "type": "string",
+      "description": "The key of the secret to select from.  Must be a valid secret key."
      }
     }
    },
@@ -13518,13 +18809,17 @@
      },
      "mountPath": {
       "type": "string",
-      "description": "Path within the container at which the volume should be mounted."
+      "description": "Path within the container at which the volume should be mounted.  Must not contain ':'."
+     },
+     "subPath": {
+      "type": "string",
+      "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root)."
      }
     }
    },
    "v1.Probe": {
     "id": "v1.Probe",
-    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to recieve traffic.",
+    "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
     "properties": {
      "exec": {
       "$ref": "v1.ExecAction",
@@ -13540,17 +18835,17 @@
      },
      "initialDelaySeconds": {
       "type": "integer",
-      "format": "int64",
-      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
+      "format": "int32",
+      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
-      "format": "int64",
-      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-probes"
+      "format": "int32",
+      "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
      },
      "periodSeconds": {
       "type": "integer",
-      "format": "int64",
+      "format": "int32",
       "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1."
      },
      "successThreshold": {
@@ -13595,11 +18890,36 @@
      },
      "host": {
       "type": "string",
-      "description": "Host name to connect to, defaults to the pod IP."
+      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead."
      },
      "scheme": {
       "type": "string",
       "description": "Scheme to use for connecting to the host. Defaults to HTTP."
+     },
+     "httpHeaders": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.HTTPHeader"
+      },
+      "description": "Custom headers to set in the request. HTTP allows repeated headers."
+     }
+    }
+   },
+   "v1.HTTPHeader": {
+    "id": "v1.HTTPHeader",
+    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+    "required": [
+     "name",
+     "value"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The header field name"
+     },
+     "value": {
+      "type": "string",
+      "description": "The header field value"
      }
     }
    },
@@ -13622,11 +18942,11 @@
     "properties": {
      "postStart": {
       "$ref": "v1.Handler",
-      "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#hook-details"
+      "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://kubernetes.io/docs/user-guide/container-environment#hook-details"
      },
      "preStop": {
       "$ref": "v1.Handler",
-      "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#hook-details"
+      "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://kubernetes.io/docs/user-guide/container-environment#hook-details"
      }
     }
    },
@@ -13672,6 +18992,10 @@
      "runAsNonRoot": {
       "type": "boolean",
       "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+     },
+     "readOnlyRootFilesystem": {
+      "type": "boolean",
+      "description": "Whether this container has a read-only root filesystem. Default is false."
      }
     }
    },
@@ -13741,7 +19065,7 @@
      "supplementalGroups": {
       "type": "array",
       "items": {
-       "$ref": "integer"
+       "type": "integer"
       },
       "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container."
      },
@@ -13752,24 +19076,20 @@
      }
     }
    },
-   "integer": {
-    "id": "integer",
-    "properties": {}
-   },
    "v1.PodStatus": {
     "id": "v1.PodStatus",
     "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system.",
     "properties": {
      "phase": {
       "type": "string",
-      "description": "Current condition of the pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-phase"
+      "description": "Current condition of the pod. More info: http://kubernetes.io/docs/user-guide/pod-states#pod-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.PodCondition"
       },
-      "description": "Current service state of pod. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "Current service state of pod. More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions"
      },
      "message": {
       "type": "string",
@@ -13789,6 +19109,7 @@
      },
      "startTime": {
       "type": "string",
+      "format": "date-time",
       "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod."
      },
      "containerStatuses": {
@@ -13796,7 +19117,7 @@
       "items": {
        "$ref": "v1.ContainerStatus"
       },
-      "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#container-statuses"
+      "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://kubernetes.io/docs/user-guide/pod-states#container-statuses"
      }
     }
    },
@@ -13810,18 +19131,20 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type is the type of the condition. Currently only Ready. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "Type is the type of the condition. Currently only Ready. More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions"
      },
      "status": {
       "type": "string",
-      "description": "Status is the status of the condition. Can be True, False, Unknown. More info: http://releases.k8s.io/HEAD/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "Status is the status of the condition. Can be True, False, Unknown. More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions"
      },
      "lastProbeTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time we probed the condition."
      },
      "lastTransitionTime": {
       "type": "string",
+      "format": "date-time",
       "description": "Last time the condition transitioned from one status to another."
      },
      "reason": {
@@ -13868,7 +19191,7 @@
      },
      "image": {
       "type": "string",
-      "description": "The image the container is running. More info: http://releases.k8s.io/HEAD/docs/user-guide/images.md"
+      "description": "The image the container is running. More info: http://kubernetes.io/docs/user-guide/images"
      },
      "imageID": {
       "type": "string",
@@ -13876,7 +19199,7 @@
      },
      "containerID": {
       "type": "string",
-      "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'. More info: http://releases.k8s.io/HEAD/docs/user-guide/container-environment.md#container-information"
+      "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'. More info: http://kubernetes.io/docs/user-guide/container-environment#container-information"
      }
     }
    },
@@ -13918,6 +19241,7 @@
     "properties": {
      "startedAt": {
       "type": "string",
+      "format": "date-time",
       "description": "Time at which the container was last (re-)started"
      }
     }
@@ -13949,15 +19273,39 @@
      },
      "startedAt": {
       "type": "string",
+      "format": "date-time",
       "description": "Time at which previous execution of the container started"
      },
      "finishedAt": {
       "type": "string",
+      "format": "date-time",
       "description": "Time at which the container last terminated"
      },
      "containerID": {
       "type": "string",
       "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'"
+     }
+    }
+   },
+   "v1beta1.Eviction": {
+    "id": "v1beta1.Eviction",
+    "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "ObjectMeta describes the pod that is being evicted."
+     },
+     "deleteOptions": {
+      "$ref": "v1.DeleteOptions",
+      "description": "DeleteOptions may be provided"
      }
     }
    },
@@ -14049,7 +19397,7 @@
       "items": {
        "$ref": "v1.ReplicationController"
       },
-      "description": "List of replication controllers. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md"
+      "description": "List of replication controllers. More info: http://kubernetes.io/docs/user-guide/replication-controller"
      }
     }
    },
@@ -14086,15 +19434,20 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+     },
+     "minReadySeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
      },
      "selector": {
-      "type": "any",
-      "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: http://releases.k8s.io/HEAD/docs/user-guide/labels.md#label-selectors"
+      "type": "object",
+      "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#pod-template"
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
      }
     }
    },
@@ -14108,12 +19461,120 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+      "description": "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+     },
+     "fullyLabeledReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of pods that have labels matching the labels of the pod template of the replication controller."
+     },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of ready replicas for this replication controller."
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of available replicas (ready for at least minReadySeconds) for this replication controller."
      },
      "observedGeneration": {
       "type": "integer",
       "format": "int64",
       "description": "ObservedGeneration reflects the generation of the most recently observed replication controller."
+     },
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ReplicationControllerCondition"
+      },
+      "description": "Represents the latest available observations of a replication controller's current state."
+     }
+    }
+   },
+   "v1.ReplicationControllerCondition": {
+    "id": "v1.ReplicationControllerCondition",
+    "description": "ReplicationControllerCondition describes the state of a replication controller at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of replication controller condition."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The last time the condition transitioned from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "The reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human readable message indicating details about the transition."
+     }
+    }
+   },
+   "v1.Scale": {
+    "id": "v1.Scale",
+    "description": "Scale represents a scaling request for a resource.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata."
+     },
+     "spec": {
+      "$ref": "v1.ScaleSpec",
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1.ScaleStatus",
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only."
+     }
+    }
+   },
+   "v1.ScaleSpec": {
+    "id": "v1.ScaleSpec",
+    "description": "ScaleSpec describes the attributes of a scale subresource.",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of instances for the scaled object."
+     }
+    }
+   },
+   "v1.ScaleStatus": {
+    "id": "v1.ScaleStatus",
+    "description": "ScaleStatus represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "actual number of observed instances of the scaled object."
+     },
+     "selector": {
+      "type": "string",
+      "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors"
      }
     }
    },
@@ -14176,21 +19637,32 @@
     "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
     "properties": {
      "hard": {
-      "type": "any",
+      "type": "object",
       "description": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+     },
+     "scopes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ResourceQuotaScope"
+      },
+      "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects."
      }
     }
+   },
+   "v1.ResourceQuotaScope": {
+    "id": "v1.ResourceQuotaScope",
+    "properties": {}
    },
    "v1.ResourceQuotaStatus": {
     "id": "v1.ResourceQuotaStatus",
     "description": "ResourceQuotaStatus defines the enforced hard limits and observed use.",
     "properties": {
      "hard": {
-      "type": "any",
+      "type": "object",
       "description": "Hard is the set of enforced hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      },
      "used": {
-      "type": "any",
+      "type": "object",
       "description": "Used is the current observed total usage of the resource in the namespace."
      }
     }
@@ -14219,7 +19691,7 @@
       "items": {
        "$ref": "v1.Secret"
       },
-      "description": "Items is a list of secret objects. More info: http://releases.k8s.io/HEAD/docs/user-guide/secrets.md"
+      "description": "Items is a list of secret objects. More info: http://kubernetes.io/docs/user-guide/secrets"
      }
     }
    },
@@ -14240,8 +19712,12 @@
       "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
      },
      "data": {
-      "type": "any",
+      "type": "object",
       "description": "Data contains the secret data. Each key must be a valid DNS_SUBDOMAIN or leading dot followed by valid DNS_SUBDOMAIN. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4"
+     },
+     "stringData": {
+      "type": "object",
+      "description": "stringData allows specifying non-binary secret data in string form. It is provided as a write-only convenience method. All keys and values are merged into the data field on write, overwriting any existing values. It is never output when reading from the API."
      },
      "type": {
       "type": "string",
@@ -14298,14 +19774,14 @@
       "items": {
        "$ref": "v1.ObjectReference"
       },
-      "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://releases.k8s.io/HEAD/docs/user-guide/secrets.md"
+      "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://kubernetes.io/docs/user-guide/secrets"
      },
      "imagePullSecrets": {
       "type": "array",
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://releases.k8s.io/HEAD/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"
+      "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://kubernetes.io/docs/user-guide/secrets#manually-specifying-an-imagepullsecret"
      }
     }
    },
@@ -14375,19 +19851,19 @@
       "items": {
        "$ref": "v1.ServicePort"
       },
-      "description": "The list of ports that are exposed by this service. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "The list of ports that are exposed by this service. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies"
      },
      "selector": {
-      "type": "any",
-      "description": "This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#overview"
+      "type": "object",
+      "description": "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: http://kubernetes.io/docs/user-guide/services#overview"
      },
      "clusterIP": {
       "type": "string",
-      "description": "ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (\"\"), or a valid IP address. 'None' can be specified for a headless service when proxying is not required. Cannot be updated. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies"
      },
      "type": {
       "type": "string",
-      "description": "Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#external-services"
+      "description": "type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. \"ExternalName\" maps to the specified externalName. \"ClusterIP\" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object. If clusterIP is \"None\", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a stable IP. \"NodePort\" builds on ClusterIP and allocates a port on every node which routes to the clusterIP. \"LoadBalancer\" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the clusterIP. More info: http://kubernetes.io/docs/user-guide/services#overview"
      },
      "externalIPs": {
       "type": "array",
@@ -14405,17 +19881,28 @@
      },
      "sessionAffinity": {
       "type": "string",
-      "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies"
      },
      "loadBalancerIP": {
       "type": "string",
       "description": "Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature."
+     },
+     "loadBalancerSourceRanges": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature.\" More info: http://kubernetes.io/docs/user-guide/services-firewalls"
+     },
+     "externalName": {
+      "type": "string",
+      "description": "externalName is the external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires Type to be ExternalName."
      }
     }
    },
    "v1.ServicePort": {
     "id": "v1.ServicePort",
-    "description": "ServicePort conatins information on service's port.",
+    "description": "ServicePort contains information on service's port.",
     "required": [
      "port"
     ],
@@ -14435,12 +19922,12 @@
      },
      "targetPort": {
       "type": "string",
-      "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#defining-a-service"
+      "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service"
      },
      "nodePort": {
       "type": "integer",
       "format": "int32",
-      "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: http://releases.k8s.io/HEAD/docs/user-guide/services.md#type--nodeport"
+      "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: http://kubernetes.io/docs/user-guide/services#type--nodeport"
      }
     }
    },
@@ -14478,6 +19965,58 @@
      "hostname": {
       "type": "string",
       "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)"
+     }
+    }
+   },
+   "unversioned.APIResourceList": {
+    "id": "unversioned.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "unversioned.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "unversioned.APIResource": {
+    "id": "unversioned.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
      }
     }
    }

--- a/resources/swagger/v1beta1.json
+++ b/resources/swagger/v1beta1.json
@@ -1,0 +1,10768 @@
+{
+ "swaggerVersion": "1.2",
+ "apiVersion": "extensions/v1beta1",
+ "basePath": "https://10.10.10.10:6443",
+ "resourcePath": "/apis/extensions/v1beta1",
+ "info": {
+  "title": "",
+  "description": ""
+ },
+ "apis": [
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DaemonSetList",
+     "method": "GET",
+     "summary": "list or watch objects of kind DaemonSet",
+     "nickname": "listNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSetList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "POST",
+     "summary": "create a DaemonSet",
+     "nickname": "createNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.DaemonSet",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of DaemonSet",
+     "nickname": "deletecollectionNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/daemonsets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of DaemonSet",
+     "nickname": "watchNamespacedDaemonSetList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "GET",
+     "summary": "read the specified DaemonSet",
+     "nickname": "readNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "PUT",
+     "summary": "replace the specified DaemonSet",
+     "nickname": "replaceNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.DaemonSet",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "PATCH",
+     "summary": "partially update the specified DaemonSet",
+     "nickname": "patchNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a DaemonSet",
+     "nickname": "deleteNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/daemonsets/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind DaemonSet",
+     "nickname": "watchNamespacedDaemonSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/daemonsets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DaemonSetList",
+     "method": "GET",
+     "summary": "list or watch objects of kind DaemonSet",
+     "nickname": "listDaemonSetForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSetList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/daemonsets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of DaemonSet",
+     "nickname": "watchDaemonSetListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "GET",
+     "summary": "read status of the specified DaemonSet",
+     "nickname": "readNamespacedDaemonSetStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "PUT",
+     "summary": "replace status of the specified DaemonSet",
+     "nickname": "replaceNamespacedDaemonSetStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.DaemonSet",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.DaemonSet",
+     "method": "PATCH",
+     "summary": "partially update status of the specified DaemonSet",
+     "nickname": "patchNamespacedDaemonSetStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DaemonSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DaemonSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DeploymentList",
+     "method": "GET",
+     "summary": "list or watch objects of kind Deployment",
+     "nickname": "listNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DeploymentList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Deployment",
+     "method": "POST",
+     "summary": "create a Deployment",
+     "nickname": "createNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Deployment",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of Deployment",
+     "nickname": "deletecollectionNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/deployments",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of Deployment",
+     "nickname": "watchNamespacedDeploymentList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Deployment",
+     "method": "GET",
+     "summary": "read the specified Deployment",
+     "nickname": "readNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Deployment",
+     "method": "PUT",
+     "summary": "replace the specified Deployment",
+     "nickname": "replaceNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Deployment",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Deployment",
+     "method": "PATCH",
+     "summary": "partially update the specified Deployment",
+     "nickname": "patchNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a Deployment",
+     "nickname": "deleteNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/deployments/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind Deployment",
+     "nickname": "watchNamespacedDeployment",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/deployments",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DeploymentList",
+     "method": "GET",
+     "summary": "list or watch objects of kind Deployment",
+     "nickname": "listDeploymentForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DeploymentList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/deployments",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of Deployment",
+     "nickname": "watchDeploymentListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.DeploymentRollback",
+     "method": "POST",
+     "summary": "create rollback of a DeploymentRollback",
+     "nickname": "createNamespacedDeploymentRollbackRollback",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.DeploymentRollback",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the DeploymentRollback",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.DeploymentRollback"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Scale",
+     "method": "GET",
+     "summary": "read scale of the specified Scale",
+     "nickname": "readNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Scale",
+     "method": "PUT",
+     "summary": "replace scale of the specified Scale",
+     "nickname": "replaceNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Scale",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Scale",
+     "method": "PATCH",
+     "summary": "partially update scale of the specified Scale",
+     "nickname": "patchNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Deployment",
+     "method": "GET",
+     "summary": "read status of the specified Deployment",
+     "nickname": "readNamespacedDeploymentStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Deployment",
+     "method": "PUT",
+     "summary": "replace status of the specified Deployment",
+     "nickname": "replaceNamespacedDeploymentStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Deployment",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Deployment",
+     "method": "PATCH",
+     "summary": "partially update status of the specified Deployment",
+     "nickname": "patchNamespacedDeploymentStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Deployment",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Deployment"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.HorizontalPodAutoscalerList",
+     "method": "GET",
+     "summary": "list or watch objects of kind HorizontalPodAutoscaler",
+     "nickname": "listNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscalerList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "POST",
+     "summary": "create a HorizontalPodAutoscaler",
+     "nickname": "createNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.HorizontalPodAutoscaler",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of HorizontalPodAutoscaler",
+     "nickname": "deletecollectionNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/horizontalpodautoscalers",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
+     "nickname": "watchNamespacedHorizontalPodAutoscalerList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "GET",
+     "summary": "read the specified HorizontalPodAutoscaler",
+     "nickname": "readNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "PUT",
+     "summary": "replace the specified HorizontalPodAutoscaler",
+     "nickname": "replaceNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.HorizontalPodAutoscaler",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "PATCH",
+     "summary": "partially update the specified HorizontalPodAutoscaler",
+     "nickname": "patchNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a HorizontalPodAutoscaler",
+     "nickname": "deleteNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/horizontalpodautoscalers/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind HorizontalPodAutoscaler",
+     "nickname": "watchNamespacedHorizontalPodAutoscaler",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/horizontalpodautoscalers",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.HorizontalPodAutoscalerList",
+     "method": "GET",
+     "summary": "list or watch objects of kind HorizontalPodAutoscaler",
+     "nickname": "listHorizontalPodAutoscalerForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscalerList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/horizontalpodautoscalers",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of HorizontalPodAutoscaler",
+     "nickname": "watchHorizontalPodAutoscalerListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "GET",
+     "summary": "read status of the specified HorizontalPodAutoscaler",
+     "nickname": "readNamespacedHorizontalPodAutoscalerStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "PUT",
+     "summary": "replace status of the specified HorizontalPodAutoscaler",
+     "nickname": "replaceNamespacedHorizontalPodAutoscalerStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.HorizontalPodAutoscaler",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.HorizontalPodAutoscaler",
+     "method": "PATCH",
+     "summary": "partially update status of the specified HorizontalPodAutoscaler",
+     "nickname": "patchNamespacedHorizontalPodAutoscalerStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the HorizontalPodAutoscaler",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.HorizontalPodAutoscaler"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.IngressList",
+     "method": "GET",
+     "summary": "list or watch objects of kind Ingress",
+     "nickname": "listNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.IngressList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Ingress",
+     "method": "POST",
+     "summary": "create an Ingress",
+     "nickname": "createNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Ingress",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of Ingress",
+     "nickname": "deletecollectionNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of Ingress",
+     "nickname": "watchNamespacedIngressList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Ingress",
+     "method": "GET",
+     "summary": "read the specified Ingress",
+     "nickname": "readNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Ingress",
+     "method": "PUT",
+     "summary": "replace the specified Ingress",
+     "nickname": "replaceNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Ingress",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Ingress",
+     "method": "PATCH",
+     "summary": "partially update the specified Ingress",
+     "nickname": "patchNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete an Ingress",
+     "nickname": "deleteNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind Ingress",
+     "nickname": "watchNamespacedIngress",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/ingresses",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.IngressList",
+     "method": "GET",
+     "summary": "list or watch objects of kind Ingress",
+     "nickname": "listIngressForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.IngressList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/ingresses",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of Ingress",
+     "nickname": "watchIngressListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Ingress",
+     "method": "GET",
+     "summary": "read status of the specified Ingress",
+     "nickname": "readNamespacedIngressStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Ingress",
+     "method": "PUT",
+     "summary": "replace status of the specified Ingress",
+     "nickname": "replaceNamespacedIngressStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Ingress",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Ingress",
+     "method": "PATCH",
+     "summary": "partially update status of the specified Ingress",
+     "nickname": "patchNamespacedIngressStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Ingress",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Ingress"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.JobList",
+     "method": "GET",
+     "summary": "list or watch objects of kind Job",
+     "nickname": "listNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.JobList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Job",
+     "method": "POST",
+     "summary": "create a Job",
+     "nickname": "createNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Job",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of Job",
+     "nickname": "deletecollectionNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/jobs",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of Job",
+     "nickname": "watchNamespacedJobList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Job",
+     "method": "GET",
+     "summary": "read the specified Job",
+     "nickname": "readNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Job",
+     "method": "PUT",
+     "summary": "replace the specified Job",
+     "nickname": "replaceNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Job",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Job",
+     "method": "PATCH",
+     "summary": "partially update the specified Job",
+     "nickname": "patchNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a Job",
+     "nickname": "deleteNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/jobs/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind Job",
+     "nickname": "watchNamespacedJob",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/jobs",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.JobList",
+     "method": "GET",
+     "summary": "list or watch objects of kind Job",
+     "nickname": "listJobForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.JobList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/jobs",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of Job",
+     "nickname": "watchJobListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}/status",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Job",
+     "method": "GET",
+     "summary": "read status of the specified Job",
+     "nickname": "readNamespacedJobStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Job",
+     "method": "PUT",
+     "summary": "replace status of the specified Job",
+     "nickname": "replaceNamespacedJobStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Job",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Job",
+     "method": "PATCH",
+     "summary": "partially update status of the specified Job",
+     "nickname": "patchNamespacedJobStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Job",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Job"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.NetworkPolicyList",
+     "method": "GET",
+     "summary": "list or watch objects of kind NetworkPolicy",
+     "nickname": "listNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.NetworkPolicyList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.NetworkPolicy",
+     "method": "POST",
+     "summary": "create a NetworkPolicy",
+     "nickname": "createNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.NetworkPolicy",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.NetworkPolicy"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of NetworkPolicy",
+     "nickname": "deletecollectionNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/networkpolicies",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of NetworkPolicy",
+     "nickname": "watchNamespacedNetworkPolicyList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.NetworkPolicy",
+     "method": "GET",
+     "summary": "read the specified NetworkPolicy",
+     "nickname": "readNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the NetworkPolicy",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.NetworkPolicy"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.NetworkPolicy",
+     "method": "PUT",
+     "summary": "replace the specified NetworkPolicy",
+     "nickname": "replaceNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.NetworkPolicy",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the NetworkPolicy",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.NetworkPolicy"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.NetworkPolicy",
+     "method": "PATCH",
+     "summary": "partially update the specified NetworkPolicy",
+     "nickname": "patchNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the NetworkPolicy",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.NetworkPolicy"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a NetworkPolicy",
+     "nickname": "deleteNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the NetworkPolicy",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/networkpolicies/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind NetworkPolicy",
+     "nickname": "watchNamespacedNetworkPolicy",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the NetworkPolicy",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/networkpolicies",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.NetworkPolicyList",
+     "method": "GET",
+     "summary": "list or watch objects of kind NetworkPolicy",
+     "nickname": "listNetworkPolicyForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.NetworkPolicyList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/networkpolicies",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of NetworkPolicy",
+     "nickname": "watchNetworkPolicyListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.ReplicaSetList",
+     "method": "GET",
+     "summary": "list or watch objects of kind ReplicaSet",
+     "nickname": "listNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSetList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "POST",
+     "summary": "create a ReplicaSet",
+     "nickname": "createNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.ReplicaSet",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of ReplicaSet",
+     "nickname": "deletecollectionNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/replicasets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of ReplicaSet",
+     "nickname": "watchNamespacedReplicaSetList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "GET",
+     "summary": "read the specified ReplicaSet",
+     "nickname": "readNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "PUT",
+     "summary": "replace the specified ReplicaSet",
+     "nickname": "replaceNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.ReplicaSet",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "PATCH",
+     "summary": "partially update the specified ReplicaSet",
+     "nickname": "patchNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a ReplicaSet",
+     "nickname": "deleteNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/replicasets/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind ReplicaSet",
+     "nickname": "watchNamespacedReplicaSet",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/replicasets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.ReplicaSetList",
+     "method": "GET",
+     "summary": "list or watch objects of kind ReplicaSet",
+     "nickname": "listReplicaSetForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSetList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/replicasets",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of ReplicaSet",
+     "nickname": "watchReplicaSetListForAllNamespaces",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Scale",
+     "method": "GET",
+     "summary": "read scale of the specified Scale",
+     "nickname": "readNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Scale",
+     "method": "PUT",
+     "summary": "replace scale of the specified Scale",
+     "nickname": "replaceNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Scale",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Scale",
+     "method": "PATCH",
+     "summary": "partially update scale of the specified Scale",
+     "nickname": "patchNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "GET",
+     "summary": "read status of the specified ReplicaSet",
+     "nickname": "readNamespacedReplicaSetStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "PUT",
+     "summary": "replace status of the specified ReplicaSet",
+     "nickname": "replaceNamespacedReplicaSetStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.ReplicaSet",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ReplicaSet",
+     "method": "PATCH",
+     "summary": "partially update status of the specified ReplicaSet",
+     "nickname": "patchNamespacedReplicaSetStatus",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ReplicaSet",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ReplicaSet"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.Scale",
+     "method": "GET",
+     "summary": "read scale of the specified Scale",
+     "nickname": "readNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Scale",
+     "method": "PUT",
+     "summary": "replace scale of the specified Scale",
+     "nickname": "replaceNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.Scale",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.Scale",
+     "method": "PATCH",
+     "summary": "partially update scale of the specified Scale",
+     "nickname": "patchNamespacedScaleScale",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "namespace",
+       "description": "object name and auth scope, such as for teams and projects",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the Scale",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.Scale"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/thirdpartyresources",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.ThirdPartyResourceList",
+     "method": "GET",
+     "summary": "list or watch objects of kind ThirdPartyResource",
+     "nickname": "listThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ThirdPartyResourceList"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ThirdPartyResource",
+     "method": "POST",
+     "summary": "create a ThirdPartyResource",
+     "nickname": "createThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.ThirdPartyResource",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ThirdPartyResource"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete collection of ThirdPartyResource",
+     "nickname": "deletecollectionThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/thirdpartyresources",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch individual changes to a list of ThirdPartyResource",
+     "nickname": "watchThirdPartyResourceList",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/thirdpartyresources/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "v1beta1.ThirdPartyResource",
+     "method": "GET",
+     "summary": "read the specified ThirdPartyResource",
+     "nickname": "readThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "export",
+       "description": "Should this value be exported.  Export strips fields that a user can not specify.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "exact",
+       "description": "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ThirdPartyResource",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ThirdPartyResource"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ThirdPartyResource",
+     "method": "PUT",
+     "summary": "replace the specified ThirdPartyResource",
+     "nickname": "replaceThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1beta1.ThirdPartyResource",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ThirdPartyResource",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ThirdPartyResource"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    },
+    {
+     "type": "v1beta1.ThirdPartyResource",
+     "method": "PATCH",
+     "summary": "partially update the specified ThirdPartyResource",
+     "nickname": "patchThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "unversioned.Patch",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ThirdPartyResource",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "v1beta1.ThirdPartyResource"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json-patch+json",
+      "application/merge-patch+json",
+      "application/strategic-merge-patch+json"
+     ]
+    },
+    {
+     "type": "unversioned.Status",
+     "method": "DELETE",
+     "summary": "delete a ThirdPartyResource",
+     "nickname": "deleteThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "v1.DeleteOptions",
+       "paramType": "body",
+       "name": "body",
+       "description": "",
+       "required": true,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "gracePeriodSeconds",
+       "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "orphanDependents",
+       "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ThirdPartyResource",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "unversioned.Status"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1/watch/thirdpartyresources/{name}",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "versioned.Event",
+     "method": "GET",
+     "summary": "watch changes to an object of kind ThirdPartyResource",
+     "nickname": "watchThirdPartyResource",
+     "parameters": [
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "pretty",
+       "description": "If 'true', then the output is pretty printed.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "labelSelector",
+       "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "fieldSelector",
+       "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "boolean",
+       "paramType": "query",
+       "name": "watch",
+       "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "query",
+       "name": "resourceVersion",
+       "description": "When specified with a watch call, shows changes that occur after that particular version of a resource. Defaults to changes from the beginning of history.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "integer",
+       "paramType": "query",
+       "name": "timeoutSeconds",
+       "description": "Timeout for the list/watch call.",
+       "required": false,
+       "allowMultiple": false
+      },
+      {
+       "type": "string",
+       "paramType": "path",
+       "name": "name",
+       "description": "name of the ThirdPartyResource",
+       "required": true,
+       "allowMultiple": false
+      }
+     ],
+     "responseMessages": [
+      {
+       "code": 200,
+       "message": "OK",
+       "responseModel": "versioned.Event"
+      }
+     ],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf",
+      "application/json;stream=watch",
+      "application/vnd.kubernetes.protobuf;stream=watch"
+     ],
+     "consumes": [
+      "*/*"
+     ]
+    }
+   ]
+  },
+  {
+   "path": "/apis/extensions/v1beta1",
+   "description": "API at /apis/extensions/v1beta1",
+   "operations": [
+    {
+     "type": "unversioned.APIResourceList",
+     "method": "GET",
+     "summary": "get available resources",
+     "nickname": "getAPIResources",
+     "parameters": [],
+     "produces": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ],
+     "consumes": [
+      "application/json",
+      "application/yaml",
+      "application/vnd.kubernetes.protobuf"
+     ]
+    }
+   ]
+  }
+ ],
+ "models": {
+  "v1beta1.DaemonSetList": {
+   "id": "v1beta1.DaemonSetList",
+   "description": "DaemonSetList is a collection of daemon sets.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.DaemonSet"
+     },
+     "description": "Items is a list of daemon sets."
+    }
+   }
+  },
+  "unversioned.ListMeta": {
+   "id": "unversioned.ListMeta",
+   "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+   "properties": {
+    "selfLink": {
+     "type": "string",
+     "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+    },
+    "resourceVersion": {
+     "type": "string",
+     "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+    }
+   }
+  },
+  "v1beta1.DaemonSet": {
+   "id": "v1beta1.DaemonSet",
+   "description": "DaemonSet represents the configuration of a daemon set.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1beta1.DaemonSetSpec",
+     "description": "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    },
+    "status": {
+     "$ref": "v1beta1.DaemonSetStatus",
+     "description": "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    }
+   }
+  },
+  "v1.ObjectMeta": {
+   "id": "v1.ObjectMeta",
+   "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "generateName": {
+     "type": "string",
+     "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#idempotency"
+    },
+    "namespace": {
+     "type": "string",
+     "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces"
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+    },
+    "uid": {
+     "type": "string",
+     "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+    },
+    "resourceVersion": {
+     "type": "string",
+     "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+    },
+    "generation": {
+     "type": "integer",
+     "format": "int64",
+     "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only."
+    },
+    "creationTimestamp": {
+     "type": "string",
+     "format": "date-time",
+     "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "deletionTimestamp": {
+     "type": "string",
+     "format": "date-time",
+     "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "deletionGracePeriodSeconds": {
+     "type": "integer",
+     "format": "int64",
+     "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only."
+    },
+    "labels": {
+     "type": "object",
+     "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels"
+    },
+    "annotations": {
+     "type": "object",
+     "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations"
+    },
+    "ownerReferences": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.OwnerReference"
+     },
+     "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller."
+    },
+    "finalizers": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed."
+    },
+    "clusterName": {
+     "type": "string",
+     "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request."
+    }
+   }
+  },
+  "v1.OwnerReference": {
+   "id": "v1.OwnerReference",
+   "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+   "required": [
+    "apiVersion",
+    "kind",
+    "name",
+    "uid"
+   ],
+   "properties": {
+    "apiVersion": {
+     "type": "string",
+     "description": "API version of the referent."
+    },
+    "kind": {
+     "type": "string",
+     "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "name": {
+     "type": "string",
+     "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "uid": {
+     "type": "string",
+     "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+    },
+    "controller": {
+     "type": "boolean",
+     "description": "If true, this reference points to the managing controller."
+    }
+   }
+  },
+  "v1beta1.DaemonSetSpec": {
+   "id": "v1beta1.DaemonSetSpec",
+   "description": "DaemonSetSpec is the specification of a daemon set.",
+   "required": [
+    "template"
+   ],
+   "properties": {
+    "selector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+    },
+    "template": {
+     "$ref": "v1.PodTemplateSpec",
+     "description": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
+    }
+   }
+  },
+  "unversioned.LabelSelector": {
+   "id": "unversioned.LabelSelector",
+   "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+   "properties": {
+    "matchLabels": {
+     "type": "object",
+     "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+    },
+    "matchExpressions": {
+     "type": "array",
+     "items": {
+      "$ref": "unversioned.LabelSelectorRequirement"
+     },
+     "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+    }
+   }
+  },
+  "unversioned.LabelSelectorRequirement": {
+   "id": "unversioned.LabelSelectorRequirement",
+   "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+   "required": [
+    "key",
+    "operator"
+   ],
+   "properties": {
+    "key": {
+     "type": "string",
+     "description": "key is the label key that the selector applies to."
+    },
+    "operator": {
+     "type": "string",
+     "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+    },
+    "values": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+    }
+   }
+  },
+  "v1.PodTemplateSpec": {
+   "id": "v1.PodTemplateSpec",
+   "description": "PodTemplateSpec describes the data a pod should have when created from a template",
+   "properties": {
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1.PodSpec",
+     "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    }
+   }
+  },
+  "v1.PodSpec": {
+   "id": "v1.PodSpec",
+   "description": "PodSpec is a description of a pod.",
+   "required": [
+    "containers"
+   ],
+   "properties": {
+    "volumes": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.Volume"
+     },
+     "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes"
+    },
+    "containers": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.Container"
+     },
+     "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers"
+    },
+    "restartPolicy": {
+     "type": "string",
+     "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://kubernetes.io/docs/user-guide/pod-states#restartpolicy"
+    },
+    "terminationGracePeriodSeconds": {
+     "type": "integer",
+     "format": "int64",
+     "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds."
+    },
+    "activeDeadlineSeconds": {
+     "type": "integer",
+     "format": "int64",
+     "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer."
+    },
+    "dnsPolicy": {
+     "type": "string",
+     "description": "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\"."
+    },
+    "nodeSelector": {
+     "type": "object",
+     "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://kubernetes.io/docs/user-guide/node-selection/README"
+    },
+    "serviceAccountName": {
+     "type": "string",
+     "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/HEAD/docs/design/service_accounts.md"
+    },
+    "serviceAccount": {
+     "type": "string",
+     "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead."
+    },
+    "nodeName": {
+     "type": "string",
+     "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements."
+    },
+    "hostNetwork": {
+     "type": "boolean",
+     "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false."
+    },
+    "hostPID": {
+     "type": "boolean",
+     "description": "Use the host's pid namespace. Optional: Default to false."
+    },
+    "hostIPC": {
+     "type": "boolean",
+     "description": "Use the host's ipc namespace. Optional: Default to false."
+    },
+    "securityContext": {
+     "$ref": "v1.PodSecurityContext",
+     "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field."
+    },
+    "imagePullSecrets": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.LocalObjectReference"
+     },
+     "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod"
+    },
+    "hostname": {
+     "type": "string",
+     "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value."
+    },
+    "subdomain": {
+     "type": "string",
+     "description": "If specified, the fully qualified Pod hostname will be \"\u003chostname\u003e.\u003csubdomain\u003e.\u003cpod namespace\u003e.svc.\u003ccluster domain\u003e\". If not specified, the pod will not have a domainname at all."
+    }
+   }
+  },
+  "v1.Volume": {
+   "id": "v1.Volume",
+   "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+   "required": [
+    "name"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "hostPath": {
+     "$ref": "v1.HostPathVolumeSource",
+     "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://kubernetes.io/docs/user-guide/volumes#hostpath"
+    },
+    "emptyDir": {
+     "$ref": "v1.EmptyDirVolumeSource",
+     "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+    },
+    "gcePersistentDisk": {
+     "$ref": "v1.GCEPersistentDiskVolumeSource",
+     "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
+    },
+    "awsElasticBlockStore": {
+     "$ref": "v1.AWSElasticBlockStoreVolumeSource",
+     "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
+    },
+    "gitRepo": {
+     "$ref": "v1.GitRepoVolumeSource",
+     "description": "GitRepo represents a git repository at a particular revision."
+    },
+    "secret": {
+     "$ref": "v1.SecretVolumeSource",
+     "description": "Secret represents a secret that should populate this volume. More info: http://kubernetes.io/docs/user-guide/volumes#secrets"
+    },
+    "nfs": {
+     "$ref": "v1.NFSVolumeSource",
+     "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
+    },
+    "iscsi": {
+     "$ref": "v1.ISCSIVolumeSource",
+     "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md"
+    },
+    "glusterfs": {
+     "$ref": "v1.GlusterfsVolumeSource",
+     "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md"
+    },
+    "persistentVolumeClaim": {
+     "$ref": "v1.PersistentVolumeClaimVolumeSource",
+     "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
+    },
+    "rbd": {
+     "$ref": "v1.RBDVolumeSource",
+     "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md"
+    },
+    "flexVolume": {
+     "$ref": "v1.FlexVolumeSource",
+     "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future."
+    },
+    "cinder": {
+     "$ref": "v1.CinderVolumeSource",
+     "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+    },
+    "cephfs": {
+     "$ref": "v1.CephFSVolumeSource",
+     "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime"
+    },
+    "flocker": {
+     "$ref": "v1.FlockerVolumeSource",
+     "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running"
+    },
+    "downwardAPI": {
+     "$ref": "v1.DownwardAPIVolumeSource",
+     "description": "DownwardAPI represents downward API about the pod that should populate this volume"
+    },
+    "fc": {
+     "$ref": "v1.FCVolumeSource",
+     "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
+    },
+    "azureFile": {
+     "$ref": "v1.AzureFileVolumeSource",
+     "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod."
+    },
+    "configMap": {
+     "$ref": "v1.ConfigMapVolumeSource",
+     "description": "ConfigMap represents a configMap that should populate this volume"
+    },
+    "vsphereVolume": {
+     "$ref": "v1.VsphereVirtualDiskVolumeSource",
+     "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine"
+    },
+    "quobyte": {
+     "$ref": "v1.QuobyteVolumeSource",
+     "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime"
+    },
+    "azureDisk": {
+     "$ref": "v1.AzureDiskVolumeSource",
+     "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod."
+    },
+    "photonPersistentDisk": {
+     "$ref": "v1.PhotonPersistentDiskVolumeSource",
+     "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine"
+    }
+   }
+  },
+  "v1.HostPathVolumeSource": {
+   "id": "v1.HostPathVolumeSource",
+   "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+   "required": [
+    "path"
+   ],
+   "properties": {
+    "path": {
+     "type": "string",
+     "description": "Path of the directory on the host. More info: http://kubernetes.io/docs/user-guide/volumes#hostpath"
+    }
+   }
+  },
+  "v1.EmptyDirVolumeSource": {
+   "id": "v1.EmptyDirVolumeSource",
+   "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+   "properties": {
+    "medium": {
+     "type": "string",
+     "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+    }
+   }
+  },
+  "v1.GCEPersistentDiskVolumeSource": {
+   "id": "v1.GCEPersistentDiskVolumeSource",
+   "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+   "required": [
+    "pdName"
+   ],
+   "properties": {
+    "pdName": {
+     "type": "string",
+     "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
+    },
+    "partition": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://kubernetes.io/docs/user-guide/volumes#gcepersistentdisk"
+    }
+   }
+  },
+  "v1.AWSElasticBlockStoreVolumeSource": {
+   "id": "v1.AWSElasticBlockStoreVolumeSource",
+   "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+   "required": [
+    "volumeID"
+   ],
+   "properties": {
+    "volumeID": {
+     "type": "string",
+     "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
+    },
+    "partition": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty)."
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://kubernetes.io/docs/user-guide/volumes#awselasticblockstore"
+    }
+   }
+  },
+  "v1.GitRepoVolumeSource": {
+   "id": "v1.GitRepoVolumeSource",
+   "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.",
+   "required": [
+    "repository"
+   ],
+   "properties": {
+    "repository": {
+     "type": "string",
+     "description": "Repository URL"
+    },
+    "revision": {
+     "type": "string",
+     "description": "Commit hash for the specified revision."
+    },
+    "directory": {
+     "type": "string",
+     "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name."
+    }
+   }
+  },
+  "v1.SecretVolumeSource": {
+   "id": "v1.SecretVolumeSource",
+   "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+   "properties": {
+    "secretName": {
+     "type": "string",
+     "description": "Name of the secret in the pod's namespace to use. More info: http://kubernetes.io/docs/user-guide/volumes#secrets"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.KeyToPath"
+     },
+     "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'."
+    },
+    "defaultMode": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+    }
+   }
+  },
+  "v1.KeyToPath": {
+   "id": "v1.KeyToPath",
+   "description": "Maps a string key to a path within a volume.",
+   "required": [
+    "key",
+    "path"
+   ],
+   "properties": {
+    "key": {
+     "type": "string",
+     "description": "The key to project."
+    },
+    "path": {
+     "type": "string",
+     "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'."
+    },
+    "mode": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+    }
+   }
+  },
+  "v1.NFSVolumeSource": {
+   "id": "v1.NFSVolumeSource",
+   "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+   "required": [
+    "server",
+    "path"
+   ],
+   "properties": {
+    "server": {
+     "type": "string",
+     "description": "Server is the hostname or IP address of the NFS server. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
+    },
+    "path": {
+     "type": "string",
+     "description": "Path that is exported by the NFS server. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://kubernetes.io/docs/user-guide/volumes#nfs"
+    }
+   }
+  },
+  "v1.ISCSIVolumeSource": {
+   "id": "v1.ISCSIVolumeSource",
+   "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+   "required": [
+    "targetPortal",
+    "iqn",
+    "lun"
+   ],
+   "properties": {
+    "targetPortal": {
+     "type": "string",
+     "description": "iSCSI target portal. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260)."
+    },
+    "iqn": {
+     "type": "string",
+     "description": "Target iSCSI Qualified Name."
+    },
+    "lun": {
+     "type": "integer",
+     "format": "int32",
+     "description": "iSCSI target lun number."
+    },
+    "iscsiInterface": {
+     "type": "string",
+     "description": "Optional: Defaults to 'default' (tcp). iSCSI interface name that uses an iSCSI transport."
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#iscsi"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false."
+    }
+   }
+  },
+  "v1.GlusterfsVolumeSource": {
+   "id": "v1.GlusterfsVolumeSource",
+   "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+   "required": [
+    "endpoints",
+    "path"
+   ],
+   "properties": {
+    "endpoints": {
+     "type": "string",
+     "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod"
+    },
+    "path": {
+     "type": "string",
+     "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod"
+    }
+   }
+  },
+  "v1.PersistentVolumeClaimVolumeSource": {
+   "id": "v1.PersistentVolumeClaimVolumeSource",
+   "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+   "required": [
+    "claimName"
+   ],
+   "properties": {
+    "claimName": {
+     "type": "string",
+     "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Will force the ReadOnly setting in VolumeMounts. Default false."
+    }
+   }
+  },
+  "v1.RBDVolumeSource": {
+   "id": "v1.RBDVolumeSource",
+   "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+   "required": [
+    "monitors",
+    "image"
+   ],
+   "properties": {
+    "monitors": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+    },
+    "image": {
+     "type": "string",
+     "description": "The rados image name. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://kubernetes.io/docs/user-guide/volumes#rbd"
+    },
+    "pool": {
+     "type": "string",
+     "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it."
+    },
+    "user": {
+     "type": "string",
+     "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+    },
+    "keyring": {
+     "type": "string",
+     "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+    },
+    "secretRef": {
+     "$ref": "v1.LocalObjectReference",
+     "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it"
+    }
+   }
+  },
+  "v1.LocalObjectReference": {
+   "id": "v1.LocalObjectReference",
+   "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    }
+   }
+  },
+  "v1.FlexVolumeSource": {
+   "id": "v1.FlexVolumeSource",
+   "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. This is an alpha feature and may change in future.",
+   "required": [
+    "driver"
+   ],
+   "properties": {
+    "driver": {
+     "type": "string",
+     "description": "Driver is the name of the driver to use for this volume."
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script."
+    },
+    "secretRef": {
+     "$ref": "v1.LocalObjectReference",
+     "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+    },
+    "options": {
+     "type": "object",
+     "description": "Optional: Extra command options if any."
+    }
+   }
+  },
+  "v1.CinderVolumeSource": {
+   "id": "v1.CinderVolumeSource",
+   "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+   "required": [
+    "volumeID"
+   ],
+   "properties": {
+    "volumeID": {
+     "type": "string",
+     "description": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md"
+    }
+   }
+  },
+  "v1.CephFSVolumeSource": {
+   "id": "v1.CephFSVolumeSource",
+   "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+   "required": [
+    "monitors"
+   ],
+   "properties": {
+    "monitors": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+    },
+    "path": {
+     "type": "string",
+     "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /"
+    },
+    "user": {
+     "type": "string",
+     "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+    },
+    "secretFile": {
+     "type": "string",
+     "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+    },
+    "secretRef": {
+     "$ref": "v1.LocalObjectReference",
+     "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it"
+    }
+   }
+  },
+  "v1.FlockerVolumeSource": {
+   "id": "v1.FlockerVolumeSource",
+   "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+   "properties": {
+    "datasetName": {
+     "type": "string",
+     "description": "Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated"
+    },
+    "datasetUUID": {
+     "type": "string",
+     "description": "UUID of the dataset. This is unique identifier of a Flocker dataset"
+    }
+   }
+  },
+  "v1.DownwardAPIVolumeSource": {
+   "id": "v1.DownwardAPIVolumeSource",
+   "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+   "properties": {
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.DownwardAPIVolumeFile"
+     },
+     "description": "Items is a list of downward API volume file"
+    },
+    "defaultMode": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+    }
+   }
+  },
+  "v1.DownwardAPIVolumeFile": {
+   "id": "v1.DownwardAPIVolumeFile",
+   "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+   "required": [
+    "path"
+   ],
+   "properties": {
+    "path": {
+     "type": "string",
+     "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+    },
+    "fieldRef": {
+     "$ref": "v1.ObjectFieldSelector",
+     "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+    },
+    "resourceFieldRef": {
+     "$ref": "v1.ResourceFieldSelector",
+     "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+    },
+    "mode": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+    }
+   }
+  },
+  "v1.ObjectFieldSelector": {
+   "id": "v1.ObjectFieldSelector",
+   "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+   "required": [
+    "fieldPath"
+   ],
+   "properties": {
+    "apiVersion": {
+     "type": "string",
+     "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\"."
+    },
+    "fieldPath": {
+     "type": "string",
+     "description": "Path of the field to select in the specified API version."
+    }
+   }
+  },
+  "v1.ResourceFieldSelector": {
+   "id": "v1.ResourceFieldSelector",
+   "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+   "required": [
+    "resource"
+   ],
+   "properties": {
+    "containerName": {
+     "type": "string",
+     "description": "Container name: required for volumes, optional for env vars"
+    },
+    "resource": {
+     "type": "string",
+     "description": "Required: resource to select"
+    },
+    "divisor": {
+     "type": "string",
+     "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+    }
+   }
+  },
+  "v1.FCVolumeSource": {
+   "id": "v1.FCVolumeSource",
+   "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+   "required": [
+    "targetWWNs",
+    "lun"
+   ],
+   "properties": {
+    "targetWWNs": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Required: FC target worldwide names (WWNs)"
+    },
+    "lun": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Required: FC target lun number"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+    }
+   }
+  },
+  "v1.AzureFileVolumeSource": {
+   "id": "v1.AzureFileVolumeSource",
+   "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+   "required": [
+    "secretName",
+    "shareName"
+   ],
+   "properties": {
+    "secretName": {
+     "type": "string",
+     "description": "the name of secret that contains Azure Storage Account Name and Key"
+    },
+    "shareName": {
+     "type": "string",
+     "description": "Share Name"
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+    }
+   }
+  },
+  "v1.ConfigMapVolumeSource": {
+   "id": "v1.ConfigMapVolumeSource",
+   "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.KeyToPath"
+     },
+     "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error. Paths must be relative and may not contain the '..' path or start with '..'."
+    },
+    "defaultMode": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+    }
+   }
+  },
+  "v1.VsphereVirtualDiskVolumeSource": {
+   "id": "v1.VsphereVirtualDiskVolumeSource",
+   "description": "Represents a vSphere volume resource.",
+   "required": [
+    "volumePath"
+   ],
+   "properties": {
+    "volumePath": {
+     "type": "string",
+     "description": "Path that identifies vSphere volume vmdk"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
+    }
+   }
+  },
+  "v1.QuobyteVolumeSource": {
+   "id": "v1.QuobyteVolumeSource",
+   "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+   "required": [
+    "registry",
+    "volume"
+   ],
+   "properties": {
+    "registry": {
+     "type": "string",
+     "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes"
+    },
+    "volume": {
+     "type": "string",
+     "description": "Volume is a string that references an already created Quobyte volume by name."
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false."
+    },
+    "user": {
+     "type": "string",
+     "description": "User to map volume access to Defaults to serivceaccount user"
+    },
+    "group": {
+     "type": "string",
+     "description": "Group to map volume access to Default is no group"
+    }
+   }
+  },
+  "v1.AzureDiskVolumeSource": {
+   "id": "v1.AzureDiskVolumeSource",
+   "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+   "required": [
+    "diskName",
+    "diskURI"
+   ],
+   "properties": {
+    "diskName": {
+     "type": "string",
+     "description": "The Name of the data disk in the blob storage"
+    },
+    "diskURI": {
+     "type": "string",
+     "description": "The URI the data disk in the blob storage"
+    },
+    "cachingMode": {
+     "$ref": "v1.AzureDataDiskCachingMode",
+     "description": "Host Caching mode: None, Read Only, Read Write."
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts."
+    }
+   }
+  },
+  "v1.AzureDataDiskCachingMode": {
+   "id": "v1.AzureDataDiskCachingMode",
+   "properties": {}
+  },
+  "v1.PhotonPersistentDiskVolumeSource": {
+   "id": "v1.PhotonPersistentDiskVolumeSource",
+   "description": "Represents a Photon Controller persistent disk resource.",
+   "required": [
+    "pdID"
+   ],
+   "properties": {
+    "pdID": {
+     "type": "string",
+     "description": "ID that identifies Photon Controller persistent disk"
+    },
+    "fsType": {
+     "type": "string",
+     "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified."
+    }
+   }
+  },
+  "v1.Container": {
+   "id": "v1.Container",
+   "description": "A single application container that you want to run within a pod.",
+   "required": [
+    "name"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated."
+    },
+    "image": {
+     "type": "string",
+     "description": "Docker image name. More info: http://kubernetes.io/docs/user-guide/images"
+    },
+    "command": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers#containers-and-commands"
+    },
+    "args": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers#containers-and-commands"
+    },
+    "workingDir": {
+     "type": "string",
+     "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated."
+    },
+    "ports": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.ContainerPort"
+     },
+     "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated."
+    },
+    "env": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.EnvVar"
+     },
+     "description": "List of environment variables to set in the container. Cannot be updated."
+    },
+    "resources": {
+     "$ref": "v1.ResourceRequirements",
+     "description": "Compute Resources required by this container. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#resources"
+    },
+    "volumeMounts": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.VolumeMount"
+     },
+     "description": "Pod volumes to mount into the container's filesystem. Cannot be updated."
+    },
+    "livenessProbe": {
+     "$ref": "v1.Probe",
+     "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
+    },
+    "readinessProbe": {
+     "$ref": "v1.Probe",
+     "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
+    },
+    "lifecycle": {
+     "$ref": "v1.Lifecycle",
+     "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated."
+    },
+    "terminationMessagePath": {
+     "type": "string",
+     "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated."
+    },
+    "imagePullPolicy": {
+     "type": "string",
+     "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/images#updating-images"
+    },
+    "securityContext": {
+     "$ref": "v1.SecurityContext",
+     "description": "Security options the pod should run with. More info: http://releases.k8s.io/HEAD/docs/design/security_context.md"
+    },
+    "stdin": {
+     "type": "boolean",
+     "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false."
+    },
+    "stdinOnce": {
+     "type": "boolean",
+     "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false"
+    },
+    "tty": {
+     "type": "boolean",
+     "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false."
+    }
+   }
+  },
+  "v1.ContainerPort": {
+   "id": "v1.ContainerPort",
+   "description": "ContainerPort represents a network port in a single container.",
+   "required": [
+    "containerPort"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services."
+    },
+    "hostPort": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 \u003c x \u003c 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this."
+    },
+    "containerPort": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 \u003c x \u003c 65536."
+    },
+    "protocol": {
+     "type": "string",
+     "description": "Protocol for port. Must be UDP or TCP. Defaults to \"TCP\"."
+    },
+    "hostIP": {
+     "type": "string",
+     "description": "What host IP to bind the external port to."
+    }
+   }
+  },
+  "v1.EnvVar": {
+   "id": "v1.EnvVar",
+   "description": "EnvVar represents an environment variable present in a Container.",
+   "required": [
+    "name"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of the environment variable. Must be a C_IDENTIFIER."
+    },
+    "value": {
+     "type": "string",
+     "description": "Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\"."
+    },
+    "valueFrom": {
+     "$ref": "v1.EnvVarSource",
+     "description": "Source for the environment variable's value. Cannot be used if value is not empty."
+    }
+   }
+  },
+  "v1.EnvVarSource": {
+   "id": "v1.EnvVarSource",
+   "description": "EnvVarSource represents a source for the value of an EnvVar.",
+   "properties": {
+    "fieldRef": {
+     "$ref": "v1.ObjectFieldSelector",
+     "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP."
+    },
+    "resourceFieldRef": {
+     "$ref": "v1.ResourceFieldSelector",
+     "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+    },
+    "configMapKeyRef": {
+     "$ref": "v1.ConfigMapKeySelector",
+     "description": "Selects a key of a ConfigMap."
+    },
+    "secretKeyRef": {
+     "$ref": "v1.SecretKeySelector",
+     "description": "Selects a key of a secret in the pod's namespace"
+    }
+   }
+  },
+  "v1.ConfigMapKeySelector": {
+   "id": "v1.ConfigMapKeySelector",
+   "description": "Selects a key from a ConfigMap.",
+   "required": [
+    "key"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "key": {
+     "type": "string",
+     "description": "The key to select."
+    }
+   }
+  },
+  "v1.SecretKeySelector": {
+   "id": "v1.SecretKeySelector",
+   "description": "SecretKeySelector selects a key of a Secret.",
+   "required": [
+    "key"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "key": {
+     "type": "string",
+     "description": "The key of the secret to select from.  Must be a valid secret key."
+    }
+   }
+  },
+  "v1.ResourceRequirements": {
+   "id": "v1.ResourceRequirements",
+   "description": "ResourceRequirements describes the compute resource requirements.",
+   "properties": {
+    "limits": {
+     "type": "object",
+     "description": "Limits describes the maximum amount of compute resources allowed. More info: http://kubernetes.io/docs/user-guide/compute-resources/"
+    },
+    "requests": {
+     "type": "object",
+     "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://kubernetes.io/docs/user-guide/compute-resources/"
+    }
+   }
+  },
+  "v1.VolumeMount": {
+   "id": "v1.VolumeMount",
+   "description": "VolumeMount describes a mounting of a Volume within a container.",
+   "required": [
+    "name",
+    "mountPath"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "This must match the Name of a Volume."
+    },
+    "readOnly": {
+     "type": "boolean",
+     "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false."
+    },
+    "mountPath": {
+     "type": "string",
+     "description": "Path within the container at which the volume should be mounted.  Must not contain ':'."
+    },
+    "subPath": {
+     "type": "string",
+     "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root)."
+    }
+   }
+  },
+  "v1.Probe": {
+   "id": "v1.Probe",
+   "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+   "properties": {
+    "exec": {
+     "$ref": "v1.ExecAction",
+     "description": "One and only one of the following should be specified. Exec specifies the action to take."
+    },
+    "httpGet": {
+     "$ref": "v1.HTTPGetAction",
+     "description": "HTTPGet specifies the http request to perform."
+    },
+    "tcpSocket": {
+     "$ref": "v1.TCPSocketAction",
+     "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported"
+    },
+    "initialDelaySeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
+    },
+    "timeoutSeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes"
+    },
+    "periodSeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1."
+    },
+    "successThreshold": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness. Minimum value is 1."
+    },
+    "failureThreshold": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1."
+    }
+   }
+  },
+  "v1.ExecAction": {
+   "id": "v1.ExecAction",
+   "description": "ExecAction describes a \"run in container\" action.",
+   "properties": {
+    "command": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy."
+    }
+   }
+  },
+  "v1.HTTPGetAction": {
+   "id": "v1.HTTPGetAction",
+   "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+   "required": [
+    "port"
+   ],
+   "properties": {
+    "path": {
+     "type": "string",
+     "description": "Path to access on the HTTP server."
+    },
+    "port": {
+     "type": "string",
+     "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+    },
+    "host": {
+     "type": "string",
+     "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead."
+    },
+    "scheme": {
+     "type": "string",
+     "description": "Scheme to use for connecting to the host. Defaults to HTTP."
+    },
+    "httpHeaders": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.HTTPHeader"
+     },
+     "description": "Custom headers to set in the request. HTTP allows repeated headers."
+    }
+   }
+  },
+  "v1.HTTPHeader": {
+   "id": "v1.HTTPHeader",
+   "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+   "required": [
+    "name",
+    "value"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "The header field name"
+    },
+    "value": {
+     "type": "string",
+     "description": "The header field value"
+    }
+   }
+  },
+  "v1.TCPSocketAction": {
+   "id": "v1.TCPSocketAction",
+   "description": "TCPSocketAction describes an action based on opening a socket",
+   "required": [
+    "port"
+   ],
+   "properties": {
+    "port": {
+     "type": "string",
+     "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+    }
+   }
+  },
+  "v1.Lifecycle": {
+   "id": "v1.Lifecycle",
+   "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+   "properties": {
+    "postStart": {
+     "$ref": "v1.Handler",
+     "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://kubernetes.io/docs/user-guide/container-environment#hook-details"
+    },
+    "preStop": {
+     "$ref": "v1.Handler",
+     "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://kubernetes.io/docs/user-guide/container-environment#hook-details"
+    }
+   }
+  },
+  "v1.Handler": {
+   "id": "v1.Handler",
+   "description": "Handler defines a specific action that should be taken",
+   "properties": {
+    "exec": {
+     "$ref": "v1.ExecAction",
+     "description": "One and only one of the following should be specified. Exec specifies the action to take."
+    },
+    "httpGet": {
+     "$ref": "v1.HTTPGetAction",
+     "description": "HTTPGet specifies the http request to perform."
+    },
+    "tcpSocket": {
+     "$ref": "v1.TCPSocketAction",
+     "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported"
+    }
+   }
+  },
+  "v1.SecurityContext": {
+   "id": "v1.SecurityContext",
+   "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+   "properties": {
+    "capabilities": {
+     "$ref": "v1.Capabilities",
+     "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
+    },
+    "privileged": {
+     "type": "boolean",
+     "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false."
+    },
+    "seLinuxOptions": {
+     "$ref": "v1.SELinuxOptions",
+     "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+    },
+    "runAsUser": {
+     "type": "integer",
+     "format": "int64",
+     "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+    },
+    "runAsNonRoot": {
+     "type": "boolean",
+     "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+    },
+    "readOnlyRootFilesystem": {
+     "type": "boolean",
+     "description": "Whether this container has a read-only root filesystem. Default is false."
+    }
+   }
+  },
+  "v1.Capabilities": {
+   "id": "v1.Capabilities",
+   "description": "Adds and removes POSIX capabilities from running containers.",
+   "properties": {
+    "add": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.Capability"
+     },
+     "description": "Added capabilities"
+    },
+    "drop": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.Capability"
+     },
+     "description": "Removed capabilities"
+    }
+   }
+  },
+  "v1.Capability": {
+   "id": "v1.Capability",
+   "properties": {}
+  },
+  "v1.SELinuxOptions": {
+   "id": "v1.SELinuxOptions",
+   "description": "SELinuxOptions are the labels to be applied to the container",
+   "properties": {
+    "user": {
+     "type": "string",
+     "description": "User is a SELinux user label that applies to the container."
+    },
+    "role": {
+     "type": "string",
+     "description": "Role is a SELinux role label that applies to the container."
+    },
+    "type": {
+     "type": "string",
+     "description": "Type is a SELinux type label that applies to the container."
+    },
+    "level": {
+     "type": "string",
+     "description": "Level is SELinux level label that applies to the container."
+    }
+   }
+  },
+  "v1.PodSecurityContext": {
+   "id": "v1.PodSecurityContext",
+   "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+   "properties": {
+    "seLinuxOptions": {
+     "$ref": "v1.SELinuxOptions",
+     "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+    },
+    "runAsUser": {
+     "type": "integer",
+     "format": "int64",
+     "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+    },
+    "runAsNonRoot": {
+     "type": "boolean",
+     "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+    },
+    "supplementalGroups": {
+     "type": "array",
+     "items": {
+      "type": "integer"
+     },
+     "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container."
+    },
+    "fsGroup": {
+     "type": "integer",
+     "format": "int64",
+     "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw "
+    }
+   }
+  },
+  "v1beta1.DaemonSetStatus": {
+   "id": "v1beta1.DaemonSetStatus",
+   "description": "DaemonSetStatus represents the current status of a daemon set.",
+   "required": [
+    "currentNumberScheduled",
+    "numberMisscheduled",
+    "desiredNumberScheduled",
+    "numberReady"
+   ],
+   "properties": {
+    "currentNumberScheduled": {
+     "type": "integer",
+     "format": "int32",
+     "description": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+    },
+    "numberMisscheduled": {
+     "type": "integer",
+     "format": "int32",
+     "description": "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+    },
+    "desiredNumberScheduled": {
+     "type": "integer",
+     "format": "int32",
+     "description": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+    },
+    "numberReady": {
+     "type": "integer",
+     "format": "int32",
+     "description": "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."
+    }
+   }
+  },
+  "unversioned.Status": {
+   "id": "unversioned.Status",
+   "description": "Status is a return value for calls that don't return other objects.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "status": {
+     "type": "string",
+     "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    },
+    "message": {
+     "type": "string",
+     "description": "A human-readable description of the status of this operation."
+    },
+    "reason": {
+     "type": "string",
+     "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+    },
+    "details": {
+     "$ref": "unversioned.StatusDetails",
+     "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+    },
+    "code": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Suggested HTTP return code for this status, 0 if not set."
+    }
+   }
+  },
+  "unversioned.StatusDetails": {
+   "id": "unversioned.StatusDetails",
+   "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+    },
+    "group": {
+     "type": "string",
+     "description": "The group attribute of the resource associated with the status StatusReason."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "causes": {
+     "type": "array",
+     "items": {
+      "$ref": "unversioned.StatusCause"
+     },
+     "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+    },
+    "retryAfterSeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "If specified, the time in seconds before the operation should be retried."
+    }
+   }
+  },
+  "unversioned.StatusCause": {
+   "id": "unversioned.StatusCause",
+   "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+   "properties": {
+    "reason": {
+     "type": "string",
+     "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+    },
+    "message": {
+     "type": "string",
+     "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+    },
+    "field": {
+     "type": "string",
+     "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+    }
+   }
+  },
+  "versioned.Event": {
+   "id": "versioned.Event",
+   "required": [
+    "type",
+    "object"
+   ],
+   "properties": {
+    "type": {
+     "type": "string"
+    },
+    "object": {
+     "type": "string"
+    }
+   }
+  },
+  "unversioned.Patch": {
+   "id": "unversioned.Patch",
+   "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+   "properties": {}
+  },
+  "v1.DeleteOptions": {
+   "id": "v1.DeleteOptions",
+   "description": "DeleteOptions may be provided when deleting an API object",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "gracePeriodSeconds": {
+     "type": "integer",
+     "format": "int64",
+     "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately."
+    },
+    "preconditions": {
+     "$ref": "v1.Preconditions",
+     "description": "Must be fulfilled before a deletion is carried out. If not possible, a 409 Conflict status will be returned."
+    },
+    "orphanDependents": {
+     "type": "boolean",
+     "description": "Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list."
+    }
+   }
+  },
+  "v1.Preconditions": {
+   "id": "v1.Preconditions",
+   "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+   "properties": {
+    "uid": {
+     "$ref": "types.UID",
+     "description": "Specifies the target UID."
+    }
+   }
+  },
+  "types.UID": {
+   "id": "types.UID",
+   "properties": {}
+  },
+  "v1beta1.DeploymentList": {
+   "id": "v1beta1.DeploymentList",
+   "description": "DeploymentList is a list of Deployments.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata."
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.Deployment"
+     },
+     "description": "Items is the list of Deployments."
+    }
+   }
+  },
+  "v1beta1.Deployment": {
+   "id": "v1beta1.Deployment",
+   "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object metadata."
+    },
+    "spec": {
+     "$ref": "v1beta1.DeploymentSpec",
+     "description": "Specification of the desired behavior of the Deployment."
+    },
+    "status": {
+     "$ref": "v1beta1.DeploymentStatus",
+     "description": "Most recently observed status of the Deployment."
+    }
+   }
+  },
+  "v1beta1.DeploymentSpec": {
+   "id": "v1beta1.DeploymentSpec",
+   "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+   "required": [
+    "template"
+   ],
+   "properties": {
+    "replicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1."
+    },
+    "selector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment."
+    },
+    "template": {
+     "$ref": "v1.PodTemplateSpec",
+     "description": "Template describes the pods that will be created."
+    },
+    "strategy": {
+     "$ref": "v1beta1.DeploymentStrategy",
+     "description": "The deployment strategy to use to replace existing pods with new ones."
+    },
+    "minReadySeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
+    },
+    "revisionHistoryLimit": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified."
+    },
+    "paused": {
+     "type": "boolean",
+     "description": "Indicates that the deployment is paused and will not be processed by the deployment controller."
+    },
+    "rollbackTo": {
+     "$ref": "v1beta1.RollbackConfig",
+     "description": "The config this deployment is rolling back to. Will be cleared after rollback is done."
+    },
+    "progressDeadlineSeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default."
+    }
+   }
+  },
+  "v1beta1.DeploymentStrategy": {
+   "id": "v1beta1.DeploymentStrategy",
+   "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+   "properties": {
+    "type": {
+     "type": "string",
+     "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate."
+    },
+    "rollingUpdate": {
+     "$ref": "v1beta1.RollingUpdateDeployment",
+     "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+    }
+   }
+  },
+  "v1beta1.RollingUpdateDeployment": {
+   "id": "v1beta1.RollingUpdateDeployment",
+   "description": "Spec to control the desired behavior of rolling update.",
+   "properties": {
+    "maxUnavailable": {
+     "type": "string",
+     "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+    },
+    "maxSurge": {
+     "type": "string",
+     "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods."
+    }
+   }
+  },
+  "v1beta1.RollbackConfig": {
+   "id": "v1beta1.RollbackConfig",
+   "properties": {
+    "revision": {
+     "type": "integer",
+     "format": "int64",
+     "description": "The revision to rollback to. If set to 0, rollbck to the last revision."
+    }
+   }
+  },
+  "v1beta1.DeploymentStatus": {
+   "id": "v1beta1.DeploymentStatus",
+   "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+   "properties": {
+    "observedGeneration": {
+     "type": "integer",
+     "format": "int64",
+     "description": "The generation observed by the deployment controller."
+    },
+    "replicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector)."
+    },
+    "updatedReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec."
+    },
+    "availableReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment."
+    },
+    "unavailableReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Total number of unavailable pods targeted by this deployment."
+    },
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.DeploymentCondition"
+     },
+     "description": "Represents the latest available observations of a deployment's current state."
+    }
+   }
+  },
+  "v1beta1.DeploymentCondition": {
+   "id": "v1beta1.DeploymentCondition",
+   "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+   "required": [
+    "type",
+    "status"
+   ],
+   "properties": {
+    "type": {
+     "type": "string",
+     "description": "Type of deployment condition."
+    },
+    "status": {
+     "type": "string",
+     "description": "Status of the condition, one of True, False, Unknown."
+    },
+    "lastUpdateTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "The last time this condition was updated."
+    },
+    "lastTransitionTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "Last time the condition transitioned from one status to another."
+    },
+    "reason": {
+     "type": "string",
+     "description": "The reason for the condition's last transition."
+    },
+    "message": {
+     "type": "string",
+     "description": "A human readable message indicating details about the transition."
+    }
+   }
+  },
+  "v1beta1.DeploymentRollback": {
+   "id": "v1beta1.DeploymentRollback",
+   "description": "DeploymentRollback stores the information required to rollback a deployment.",
+   "required": [
+    "name",
+    "rollbackTo"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "name": {
+     "type": "string",
+     "description": "Required: This must match the Name of a deployment."
+    },
+    "updatedAnnotations": {
+     "type": "object",
+     "description": "The annotations to be updated to a deployment"
+    },
+    "rollbackTo": {
+     "$ref": "v1beta1.RollbackConfig",
+     "description": "The config of this deployment rollback."
+    }
+   }
+  },
+  "v1beta1.Scale": {
+   "id": "v1beta1.Scale",
+   "description": "represents a scaling request for a resource.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata."
+    },
+    "spec": {
+     "$ref": "v1beta1.ScaleSpec",
+     "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+    },
+    "status": {
+     "$ref": "v1beta1.ScaleStatus",
+     "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only."
+    }
+   }
+  },
+  "v1beta1.ScaleSpec": {
+   "id": "v1beta1.ScaleSpec",
+   "description": "describes the attributes of a scale subresource",
+   "properties": {
+    "replicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "desired number of instances for the scaled object."
+    }
+   }
+  },
+  "v1beta1.ScaleStatus": {
+   "id": "v1beta1.ScaleStatus",
+   "description": "represents the current status of a scale subresource.",
+   "required": [
+    "replicas"
+   ],
+   "properties": {
+    "replicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "actual number of observed instances of the scaled object."
+    },
+    "selector": {
+     "type": "object",
+     "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+    },
+    "targetSelector": {
+     "type": "string",
+     "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+    }
+   }
+  },
+  "v1beta1.HorizontalPodAutoscalerList": {
+   "id": "v1beta1.HorizontalPodAutoscalerList",
+   "description": "list of horizontal pod autoscaler objects.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata."
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.HorizontalPodAutoscaler"
+     },
+     "description": "list of horizontal pod autoscaler objects."
+    }
+   }
+  },
+  "v1beta1.HorizontalPodAutoscaler": {
+   "id": "v1beta1.HorizontalPodAutoscaler",
+   "description": "configuration of a horizontal pod autoscaler.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1beta1.HorizontalPodAutoscalerSpec",
+     "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+    },
+    "status": {
+     "$ref": "v1beta1.HorizontalPodAutoscalerStatus",
+     "description": "current information about the autoscaler."
+    }
+   }
+  },
+  "v1beta1.HorizontalPodAutoscalerSpec": {
+   "id": "v1beta1.HorizontalPodAutoscalerSpec",
+   "description": "specification of a horizontal pod autoscaler.",
+   "required": [
+    "scaleRef",
+    "maxReplicas"
+   ],
+   "properties": {
+    "scaleRef": {
+     "$ref": "v1beta1.SubresourceReference",
+     "description": "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec."
+    },
+    "minReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "lower limit for the number of pods that can be set by the autoscaler, default 1."
+    },
+    "maxReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas."
+    },
+    "cpuUtilization": {
+     "$ref": "v1beta1.CPUTargetUtilization",
+     "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources."
+    }
+   }
+  },
+  "v1beta1.SubresourceReference": {
+   "id": "v1beta1.SubresourceReference",
+   "description": "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "name": {
+     "type": "string",
+     "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "API version of the referent"
+    },
+    "subresource": {
+     "type": "string",
+     "description": "Subresource name of the referent"
+    }
+   }
+  },
+  "v1beta1.CPUTargetUtilization": {
+   "id": "v1beta1.CPUTargetUtilization",
+   "required": [
+    "targetPercentage"
+   ],
+   "properties": {
+    "targetPercentage": {
+     "type": "integer",
+     "format": "int32",
+     "description": "fraction of the requested CPU that should be utilized/used, e.g. 70 means that 70% of the requested CPU should be in use."
+    }
+   }
+  },
+  "v1beta1.HorizontalPodAutoscalerStatus": {
+   "id": "v1beta1.HorizontalPodAutoscalerStatus",
+   "description": "current status of a horizontal pod autoscaler",
+   "required": [
+    "currentReplicas",
+    "desiredReplicas"
+   ],
+   "properties": {
+    "observedGeneration": {
+     "type": "integer",
+     "format": "int64",
+     "description": "most recent generation observed by this autoscaler."
+    },
+    "lastScaleTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
+    },
+    "currentReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "current number of replicas of pods managed by this autoscaler."
+    },
+    "desiredReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "desired number of replicas of pods managed by this autoscaler."
+    },
+    "currentCPUUtilizationPercentage": {
+     "type": "integer",
+     "format": "int32",
+     "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU."
+    }
+   }
+  },
+  "v1beta1.IngressList": {
+   "id": "v1beta1.IngressList",
+   "description": "IngressList is a collection of Ingress.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.Ingress"
+     },
+     "description": "Items is the list of Ingress."
+    }
+   }
+  },
+  "v1beta1.Ingress": {
+   "id": "v1beta1.Ingress",
+   "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1beta1.IngressSpec",
+     "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    },
+    "status": {
+     "$ref": "v1beta1.IngressStatus",
+     "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    }
+   }
+  },
+  "v1beta1.IngressSpec": {
+   "id": "v1beta1.IngressSpec",
+   "description": "IngressSpec describes the Ingress the user wishes to exist.",
+   "properties": {
+    "backend": {
+     "$ref": "v1beta1.IngressBackend",
+     "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default."
+    },
+    "tls": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.IngressTLS"
+     },
+     "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI."
+    },
+    "rules": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.IngressRule"
+     },
+     "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend."
+    }
+   }
+  },
+  "v1beta1.IngressBackend": {
+   "id": "v1beta1.IngressBackend",
+   "description": "IngressBackend describes all endpoints for a given service and port.",
+   "required": [
+    "serviceName",
+    "servicePort"
+   ],
+   "properties": {
+    "serviceName": {
+     "type": "string",
+     "description": "Specifies the name of the referenced service."
+    },
+    "servicePort": {
+     "type": "string",
+     "description": "Specifies the port of the referenced service."
+    }
+   }
+  },
+  "v1beta1.IngressTLS": {
+   "id": "v1beta1.IngressTLS",
+   "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+   "properties": {
+    "hosts": {
+     "type": "array",
+     "items": {
+      "type": "string"
+     },
+     "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
+    },
+    "secretName": {
+     "type": "string",
+     "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+    }
+   }
+  },
+  "v1beta1.IngressRule": {
+   "id": "v1beta1.IngressRule",
+   "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+   "properties": {
+    "host": {
+     "type": "string",
+     "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
+    },
+    "http": {
+     "$ref": "v1beta1.HTTPIngressRuleValue"
+    }
+   }
+  },
+  "v1beta1.HTTPIngressRuleValue": {
+   "id": "v1beta1.HTTPIngressRuleValue",
+   "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+   "required": [
+    "paths"
+   ],
+   "properties": {
+    "paths": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.HTTPIngressPath"
+     },
+     "description": "A collection of paths that map requests to backends."
+    }
+   }
+  },
+  "v1beta1.HTTPIngressPath": {
+   "id": "v1beta1.HTTPIngressPath",
+   "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+   "required": [
+    "backend"
+   ],
+   "properties": {
+    "path": {
+     "type": "string",
+     "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
+    },
+    "backend": {
+     "$ref": "v1beta1.IngressBackend",
+     "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+    }
+   }
+  },
+  "v1beta1.IngressStatus": {
+   "id": "v1beta1.IngressStatus",
+   "description": "IngressStatus describe the current state of the Ingress.",
+   "properties": {
+    "loadBalancer": {
+     "$ref": "v1.LoadBalancerStatus",
+     "description": "LoadBalancer contains the current status of the load-balancer."
+    }
+   }
+  },
+  "v1.LoadBalancerStatus": {
+   "id": "v1.LoadBalancerStatus",
+   "description": "LoadBalancerStatus represents the status of a load-balancer.",
+   "properties": {
+    "ingress": {
+     "type": "array",
+     "items": {
+      "$ref": "v1.LoadBalancerIngress"
+     },
+     "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points."
+    }
+   }
+  },
+  "v1.LoadBalancerIngress": {
+   "id": "v1.LoadBalancerIngress",
+   "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
+   "properties": {
+    "ip": {
+     "type": "string",
+     "description": "IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)"
+    },
+    "hostname": {
+     "type": "string",
+     "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)"
+    }
+   }
+  },
+  "v1beta1.JobList": {
+   "id": "v1beta1.JobList",
+   "description": "JobList is a collection of jobs. DEPRECATED: extensions/v1beta1.JobList is deprecated, use batch/v1.JobList instead.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.Job"
+     },
+     "description": "Items is the list of Job."
+    }
+   }
+  },
+  "v1beta1.Job": {
+   "id": "v1beta1.Job",
+   "description": "Job represents the configuration of a single job. DEPRECATED: extensions/v1beta1.Job is deprecated, use batch/v1.Job instead.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1beta1.JobSpec",
+     "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    },
+    "status": {
+     "$ref": "v1beta1.JobStatus",
+     "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    }
+   }
+  },
+  "v1beta1.JobSpec": {
+   "id": "v1beta1.JobSpec",
+   "description": "JobSpec describes how the job execution will look like.",
+   "required": [
+    "template"
+   ],
+   "properties": {
+    "parallelism": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs"
+    },
+    "completions": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs"
+    },
+    "activeDeadlineSeconds": {
+     "type": "integer",
+     "format": "int64",
+     "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer"
+    },
+    "selector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+    },
+    "autoSelector": {
+     "type": "boolean",
+     "description": "AutoSelector controls generation of pod labels and pod selectors. It was not present in the original extensions/v1beta1 Job definition, but exists to allow conversion from batch/v1 Jobs, where it corresponds to, but has the opposite meaning as, ManualSelector. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md"
+    },
+    "template": {
+     "$ref": "v1.PodTemplateSpec",
+     "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs"
+    }
+   }
+  },
+  "v1beta1.JobStatus": {
+   "id": "v1beta1.JobStatus",
+   "description": "JobStatus represents the current state of a Job.",
+   "properties": {
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.JobCondition"
+     },
+     "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs"
+    },
+    "startTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
+    },
+    "completionTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
+    },
+    "active": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Active is the number of actively running pods."
+    },
+    "succeeded": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Succeeded is the number of pods which reached Phase Succeeded."
+    },
+    "failed": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Failed is the number of pods which reached Phase Failed."
+    }
+   }
+  },
+  "v1beta1.JobCondition": {
+   "id": "v1beta1.JobCondition",
+   "description": "JobCondition describes current state of a job.",
+   "required": [
+    "type",
+    "status"
+   ],
+   "properties": {
+    "type": {
+     "type": "string",
+     "description": "Type of job condition, Complete or Failed."
+    },
+    "status": {
+     "type": "string",
+     "description": "Status of the condition, one of True, False, Unknown."
+    },
+    "lastProbeTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "Last time the condition was checked."
+    },
+    "lastTransitionTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "Last time the condition transit from one status to another."
+    },
+    "reason": {
+     "type": "string",
+     "description": "(brief) reason for the condition's last transition."
+    },
+    "message": {
+     "type": "string",
+     "description": "Human readable message indicating details about last transition."
+    }
+   }
+  },
+  "v1beta1.NetworkPolicyList": {
+   "id": "v1beta1.NetworkPolicyList",
+   "description": "Network Policy List is a list of NetworkPolicy objects.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.NetworkPolicy"
+     },
+     "description": "Items is a list of schema objects."
+    }
+   }
+  },
+  "v1beta1.NetworkPolicy": {
+   "id": "v1beta1.NetworkPolicy",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1beta1.NetworkPolicySpec",
+     "description": "Specification of the desired behavior for this NetworkPolicy."
+    }
+   }
+  },
+  "v1beta1.NetworkPolicySpec": {
+   "id": "v1beta1.NetworkPolicySpec",
+   "required": [
+    "podSelector"
+   ],
+   "properties": {
+    "podSelector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace."
+    },
+    "ingress": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.NetworkPolicyIngressRule"
+     },
+     "description": "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if namespace.networkPolicy.ingress.isolation is undefined and cluster policy allows it, OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not affect ingress isolation. If this field is present and contains at least one rule, this policy allows any traffic which matches at least one of the ingress rules in this list."
+    }
+   }
+  },
+  "v1beta1.NetworkPolicyIngressRule": {
+   "id": "v1beta1.NetworkPolicyIngressRule",
+   "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+   "properties": {
+    "ports": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.NetworkPolicyPort"
+     },
+     "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is not provided, this rule matches all ports (traffic not restricted by port). If this field is empty, this rule matches no ports (no traffic matches). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list."
+    },
+    "from": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.NetworkPolicyPeer"
+     },
+     "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is not provided, this rule matches all sources (traffic not restricted by source). If this field is empty, this rule matches no sources (no traffic matches). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list."
+    }
+   }
+  },
+  "v1beta1.NetworkPolicyPort": {
+   "id": "v1beta1.NetworkPolicyPort",
+   "properties": {
+    "protocol": {
+     "$ref": "v1.Protocol",
+     "description": "Optional.  The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP."
+    },
+    "port": {
+     "type": "string",
+     "description": "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched."
+    }
+   }
+  },
+  "v1.Protocol": {
+   "id": "v1.Protocol",
+   "properties": {}
+  },
+  "v1beta1.NetworkPolicyPeer": {
+   "id": "v1beta1.NetworkPolicyPeer",
+   "properties": {
+    "podSelector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If not provided, this selector selects no pods. If present but empty, this selector selects all pods in this namespace."
+    },
+    "namespaceSelector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If omitted, this selector selects no namespaces. If present but empty, this selector selects all namespaces."
+    }
+   }
+  },
+  "v1beta1.ReplicaSetList": {
+   "id": "v1beta1.ReplicaSetList",
+   "description": "ReplicaSetList is a collection of ReplicaSets.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.ReplicaSet"
+     },
+     "description": "List of ReplicaSets. More info: http://kubernetes.io/docs/user-guide/replication-controller"
+    }
+   }
+  },
+  "v1beta1.ReplicaSet": {
+   "id": "v1beta1.ReplicaSet",
+   "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+    },
+    "spec": {
+     "$ref": "v1beta1.ReplicaSetSpec",
+     "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    },
+    "status": {
+     "$ref": "v1beta1.ReplicaSetStatus",
+     "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+    }
+   }
+  },
+  "v1beta1.ReplicaSetSpec": {
+   "id": "v1beta1.ReplicaSetSpec",
+   "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+   "properties": {
+    "replicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+    },
+    "minReadySeconds": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
+    },
+    "selector": {
+     "$ref": "unversioned.LabelSelector",
+     "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+    },
+    "template": {
+     "$ref": "v1.PodTemplateSpec",
+     "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
+    }
+   }
+  },
+  "v1beta1.ReplicaSetStatus": {
+   "id": "v1beta1.ReplicaSetStatus",
+   "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+   "required": [
+    "replicas"
+   ],
+   "properties": {
+    "replicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+    },
+    "fullyLabeledReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The number of pods that have labels matching the labels of the pod template of the replicaset."
+    },
+    "readyReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The number of ready replicas for this replica set."
+    },
+    "availableReplicas": {
+     "type": "integer",
+     "format": "int32",
+     "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set."
+    },
+    "observedGeneration": {
+     "type": "integer",
+     "format": "int64",
+     "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet."
+    },
+    "conditions": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.ReplicaSetCondition"
+     },
+     "description": "Represents the latest available observations of a replica set's current state."
+    }
+   }
+  },
+  "v1beta1.ReplicaSetCondition": {
+   "id": "v1beta1.ReplicaSetCondition",
+   "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+   "required": [
+    "type",
+    "status"
+   ],
+   "properties": {
+    "type": {
+     "type": "string",
+     "description": "Type of replica set condition."
+    },
+    "status": {
+     "type": "string",
+     "description": "Status of the condition, one of True, False, Unknown."
+    },
+    "lastTransitionTime": {
+     "type": "string",
+     "format": "date-time",
+     "description": "The last time the condition transitioned from one status to another."
+    },
+    "reason": {
+     "type": "string",
+     "description": "The reason for the condition's last transition."
+    },
+    "message": {
+     "type": "string",
+     "description": "A human readable message indicating details about the transition."
+    }
+   }
+  },
+  "v1beta1.ThirdPartyResourceList": {
+   "id": "v1beta1.ThirdPartyResourceList",
+   "description": "ThirdPartyResourceList is a list of ThirdPartyResources.",
+   "required": [
+    "items"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "unversioned.ListMeta",
+     "description": "Standard list metadata."
+    },
+    "items": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.ThirdPartyResource"
+     },
+     "description": "Items is the list of ThirdPartyResources."
+    }
+   }
+  },
+  "v1beta1.ThirdPartyResource": {
+   "id": "v1beta1.ThirdPartyResource",
+   "description": "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "metadata": {
+     "$ref": "v1.ObjectMeta",
+     "description": "Standard object metadata"
+    },
+    "description": {
+     "type": "string",
+     "description": "Description is the description of this object."
+    },
+    "versions": {
+     "type": "array",
+     "items": {
+      "$ref": "v1beta1.APIVersion"
+     },
+     "description": "Versions are versions for this third party object"
+    }
+   }
+  },
+  "v1beta1.APIVersion": {
+   "id": "v1beta1.APIVersion",
+   "description": "An APIVersion represents a single concrete version of an object model.",
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of this version (e.g. 'v1')."
+    }
+   }
+  },
+  "unversioned.APIResourceList": {
+   "id": "unversioned.APIResourceList",
+   "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+   "required": [
+    "groupVersion",
+    "resources"
+   ],
+   "properties": {
+    "kind": {
+     "type": "string",
+     "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+    },
+    "apiVersion": {
+     "type": "string",
+     "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+    },
+    "groupVersion": {
+     "type": "string",
+     "description": "groupVersion is the group and version this APIResourceList is for."
+    },
+    "resources": {
+     "type": "array",
+     "items": {
+      "$ref": "unversioned.APIResource"
+     },
+     "description": "resources contains the name of the resources and if they are namespaced."
+    }
+   }
+  },
+  "unversioned.APIResource": {
+   "id": "unversioned.APIResource",
+   "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+   "required": [
+    "name",
+    "namespaced",
+    "kind"
+   ],
+   "properties": {
+    "name": {
+     "type": "string",
+     "description": "name is the name of the resource."
+    },
+    "namespaced": {
+     "type": "boolean",
+     "description": "namespaced indicates if a resource is namespaced or not."
+    },
+    "kind": {
+     "type": "string",
+     "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+    }
+   }
+  }
+ }
+}

--- a/scripts/get_swagger_json.sh
+++ b/scripts/get_swagger_json.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-if [[ -z ${1} ]]; then
-    echo "usage: scripts/get_swagger_json.sh <version>"
-    exit 1
-fi
-
-curl -f "http://kubernetes.io/swagger-spec/api/${1}/" -o resources/swagger/${1}.json

--- a/src/kubernetes/api/v1.clj
+++ b/src/kubernetes/api/v1.clj
@@ -1,6 +1,4 @@
 (ns kubernetes.api.v1
-  "Kubernetes v1 API. Auto-generated via macros from swagger documentation.
-   Swagger doc is available from kubernetes.io/swagger-spec/api/v1"
   (:require [kubernetes.api.swagger :as swagger]
             [kubernetes.api.util :as util]))
 

--- a/src/kubernetes/api/v1beta1.clj
+++ b/src/kubernetes/api/v1beta1.clj
@@ -1,6 +1,4 @@
 (ns kubernetes.api.v1beta1
-  "Kubernetes v1 API. Auto-generated via macros from swagger documentation.
-   Swagger doc is available from kubernetes.io/swagger-spec/api/v1"
   (:require [kubernetes.api.swagger :as swagger]
             [kubernetes.api.util :as util]))
 

--- a/src/kubernetes/api/v1beta1.clj
+++ b/src/kubernetes/api/v1beta1.clj
@@ -1,0 +1,9 @@
+(ns kubernetes.api.v1beta1
+  "Kubernetes v1 API. Auto-generated via macros from swagger documentation.
+   Swagger doc is available from kubernetes.io/swagger-spec/api/v1"
+  (:require [kubernetes.api.swagger :as swagger]
+            [kubernetes.api.util :as util]))
+
+(def make-context util/make-context)
+
+(swagger/render-full-api "v1beta1")

--- a/test/kubernetes/api/v1_test.clj
+++ b/test/kubernetes/api/v1_test.clj
@@ -16,18 +16,18 @@
 
 (use-fixtures :once
   (fn [f]
-    (<!! (v1/create-namespaced-namespace ctx {:metadata {:name tns}}))
+    (<!! (v1/create-namespace ctx {:metadata {:name tns}}))
     (<!! (async/timeout 2000))
     (f)
-    (<!! (v1/delete-namespaced-namespace ctx {} {:name tns}))))
+    (<!! (v1/delete-namespace ctx {} {:name tns}))))
 
 (deftest node-test
   (testing "get all nodes"
-    (let [{:keys [kind items]} (<!! (v1/list-namespaced-node ctx))]
+    (let [{:keys [kind items]} (<!! (v1/list-node ctx))]
       (is (= kind "NodeList"))
       (is (= (count items) 1))))
   (testing "get nodes with options"
-    (let [{:keys [kind]} (<!! (v1/list-namespaced-node ctx nsopt))]
+    (let [{:keys [kind]} (<!! (v1/list-node ctx nsopt))]
       (is (= kind "NodeList")))))
 
 (deftest pod-test
@@ -44,7 +44,7 @@
         (is (= kind "Pod"))
         (is (= @name (:name metadata)))))
     (testing "list-pod"
-      (let [{:keys [kind items]} (<!! (v1/list-pod ctx))]
+      (let [{:keys [kind items]} (<!! (v1/list-namespaced-pod ctx nsopt))]
         (is (= kind "PodList"))
         (is (some #(= @name (get-in % [:metadata :name])) items))))
     (testing "list-namespaced-pod"

--- a/test/kubernetes/api/v1beta1_test.clj
+++ b/test/kubernetes/api/v1beta1_test.clj
@@ -1,0 +1,52 @@
+(ns kubernetes.api.v1beta1-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [clojure.core.async :refer [<!!] :as async]
+            [kubernetes.api.v1 :as v1]
+            [kubernetes.api.v1beta1 :as v1beta1]))
+
+(defn random-name []
+  (->> (repeatedly 10 #(rand-int 26))
+       (map #(nth (char-array "abcdefghijklmnopqrstuvwxyz") %))
+       (str/join "")))
+
+(def ctx (v1beta1/make-context "http://localhost:8080"))
+(def tns (random-name))
+(def deployment-name (random-name))
+
+(def nsopt {:namespace tns})
+(def deployment {:apiVersion "extensions/v1beta1"
+                 :kind       "Deployment"
+                 :metadata   {:name deployment-name}
+                 :spec       {:template {:metadata {:labels {:service "service"}}
+                                         :spec     {:containers [{:name  "nginx"
+                                                                  :image "nginx"}]}}}})
+
+
+(use-fixtures :once
+              (fn [f]
+                (<!! (v1/create-namespace ctx {:metadata {:name tns}}))
+                (<!! (async/timeout 2000))
+                (f)
+                (<!! (v1/delete-namespace ctx {} {:name tns}))))
+
+(deftest deployment-test
+  (testing "creation of deployments"
+    (let [{:keys[kind metadata]} (<!! (v1beta1/create-namespaced-deployment ctx deployment nsopt))]
+      (is (= kind "Deployment"))
+      (is (= (:name metadata) deployment-name))))
+
+  (testing "listing deployments"
+    (let [deployments (<!! (v1beta1/list-namespaced-deployment ctx nsopt))]
+      (is (= deployment-name (-> deployments :items first :metadata :name)))
+      (is (= "DeploymentList" (:kind deployments)))))
+
+  (testing "reading single deployment"
+    (let [{:keys[kind metadata]} (<!! (v1beta1/read-namespaced-deployment ctx (assoc nsopt :name deployment-name)))]
+      (is (= kind "Deployment"))
+      (is (= (:name metadata) deployment-name))))
+
+  (testing "deleting deployment"
+    (let [_ (<!! (v1beta1/delete-namespaced-deployment ctx {} (assoc nsopt :name deployment-name)))
+          {:keys [reason]} (<!! (v1beta1/read-namespaced-deployment ctx (assoc nsopt :name deployment-name)))]
+      (is (= "NotFound" reason)))))


### PR DESCRIPTION
`v1beta1` contains a bunch of stuff, including deployments.
I also updated the very old `v1.json` to the 1.5 kubernetes version.

The scripts that fetch the swagger spec from an uri were removed because the uri returns an old version of specs.