### PR TITLE
fix link typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the dependency to your `project.clj`.
 
 First, run a kubernetes proxy with `kubectl proxy --port=8080`.
 
-Each endpoint function returns a [core.async](https://github.com/clojure/core.async) channel. Under the covers, the [http-kit](www.http-kit.org) http client is used.
+Each endpoint function returns a [core.async](https://github.com/clojure/core.async) channel. Under the covers, the [http-kit](https://www.http-kit.org) http client is used.
 
 ```clojure
 (require '[kubernetes.api.v1 :as k8s]


### PR DESCRIPTION
incorrectly pointing as a subdomain of github