### PR TITLE
Support merge patch requests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,11 @@
-(defproject kubernetes-api "0.3.2-SNAPSHOT"
+(defproject kubernetes-api "0.3.3-SNAPSHOT"
   :description "Kubernetes Client API Library"
   :url "https://github.com/yanatan16/clj-kubernetes-api"
   :license {:name "MIT"
             :url "https://github.com/yanatan16/clj-kubernetes-api/blob/master/LICENSE"}
 
-  :plugins [[s3-wagon-private "1.3.0"]]
-
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/core.async "0.2.374"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+                 [org.clojure/core.async "0.3.442"]
                  [org.clojure/data.json "0.2.6"]
                  [http-kit "2.1.18"]]
 

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,8 @@
   :license {:name "MIT"
             :url "https://github.com/yanatan16/clj-kubernetes-api/blob/master/LICENSE"}
 
+  :plugins [[s3-wagon-private "1.3.0"]]
+
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [org.clojure/core.async "0.3.442"]
                  [org.clojure/data.json "0.2.6"]

--- a/src/kubernetes/api/util.clj
+++ b/src/kubernetes/api/util.clj
@@ -33,13 +33,14 @@
     :else (json/read-str body :key-fn keyword)))
 
 (defn request [ctx {:keys [method path params query body]}]
-  (let [c (chan)]
+  (let [c (chan)
+        content-type (if (= method :patch) "application/merge-patch+json" "application/json")]
     (http/request
      (cond-> {:url (url ctx path params query)
               :method method
               :as :text}
        body (assoc :body (json/write-str body)
-                   :content-type :json))
+                   :headers  {"Content-Type" content-type}))
      #(go (let [resp (parse-response %)]
             #_(println "Request" method path query body resp)
             (>! c resp))))

--- a/test/kubernetes/api/extensions_v1beta1_test.clj
+++ b/test/kubernetes/api/extensions_v1beta1_test.clj
@@ -56,6 +56,6 @@
       (is (= (:name metadata) deployment-name))))
 
   (testing "deleting deployment"
-    (let [_ 1 #_(<!! (e-v1beta1/delete-namespaced-deployment ctx {} (assoc nsopt :name deployment-name)))
+    (let [_ (<!! (e-v1beta1/delete-namespaced-deployment ctx {} (assoc nsopt :name deployment-name)))
           {:keys [reason]} (<!! (e-v1beta1/read-namespaced-deployment ctx (assoc nsopt :name deployment-name)))]
       (is (= "NotFound" reason)))))

--- a/test/kubernetes/api/extensions_v1beta1_test.clj
+++ b/test/kubernetes/api/extensions_v1beta1_test.clj
@@ -36,6 +36,15 @@
       (is (= kind "Deployment"))
       (is (= (:name metadata) deployment-name))))
 
+  (testing "updating deployments"
+    (let [new-image "nginx:1.13.3"
+          patch-param {:spec {:template {:spec {:containers [{:name "nginx"
+                                                              :image new-image}]}}}}
+          updated-image (->> (assoc nsopt :name deployment-name)
+                             (e-v1beta1/patch-namespaced-deployment ctx patch-param)
+                             (<!!) :spec :template :spec :containers first :image)]
+      (is (= updated-image new-image))))
+
   (testing "listing deployments"
     (let [deployments (<!! (e-v1beta1/list-namespaced-deployment ctx nsopt))]
       (is (= deployment-name (-> deployments :items first :metadata :name)))
@@ -47,6 +56,6 @@
       (is (= (:name metadata) deployment-name))))
 
   (testing "deleting deployment"
-    (let [_ (<!! (e-v1beta1/delete-namespaced-deployment ctx {} (assoc nsopt :name deployment-name)))
+    (let [_ 1 #_(<!! (e-v1beta1/delete-namespaced-deployment ctx {} (assoc nsopt :name deployment-name)))
           {:keys [reason]} (<!! (e-v1beta1/read-namespaced-deployment ctx (assoc nsopt :name deployment-name)))]
       (is (= "NotFound" reason)))))


### PR DESCRIPTION
The `Content-Type` for patch requests must be either `"application/json-patch+json"`, `"application/merge-patch+json"` or `"application/strategic-merge-patch+json"`.
Since for now merging is what we want, I'm adding support for that.

