### PR TITLE
Use strategic merge for patches

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kubernetes-api "0.7.0"
+(defproject kubernetes-api "1.0.0"
   :description "Kubernetes Client API Library"
   :url "https://github.com/yanatan16/clj-kubernetes-api"
   :license {:name "MIT"

--- a/src/kubernetes/api/util.clj
+++ b/src/kubernetes/api/util.clj
@@ -38,7 +38,7 @@
 
 (defn- content-type [method]
   (if (= method :patch)
-    "application/merge-patch+json"
+    "application/strategic-merge-patch+json"
     "application/json"))
 
 (defn parse-response [{:keys [status headers body error]}]

--- a/test/kubernetes/api/util_test.clj
+++ b/test/kubernetes/api/util_test.clj
@@ -20,4 +20,12 @@
                   :path "/foo"}
             request-opts (#'util/request-opts ctx opts)]
         (is (false? (:insecure? request-opts)))
-        (is (= "fake ssl engine" (:sslengine request-opts)))))))
+        (is (= "fake ssl engine" (:sslengine request-opts))))))
+
+  (testing "when the request method is PATCH, the content type is set to strategic-merge-patch+json"
+    (let [ctx {:username "username"
+               :password "password"}
+          opts {:method :patch
+                :path "/foo"}
+          request-opts (#'util/request-opts ctx opts)]
+      (is (= "application/strategic-merge-patch+json" (get-in request-opts [:headers "Content-Type"]))))))


### PR DESCRIPTION
This changes the default from `application/merge-patch+json`, so we don't have to deal with JSON patch when all we want is to set a new image for deployments.