### PR TITLE
 Add support for dynamic bearer tokens

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject kubernetes-api "1.1.0"
+(defproject kubernetes-api "1.2.0"
   :description "Kubernetes Client API Library"
   :url "https://github.com/yanatan16/clj-kubernetes-api"
   :license {:name "MIT"

--- a/src/kubernetes/api/util.clj
+++ b/src/kubernetes/api/util.clj
@@ -67,24 +67,29 @@
    :insecure? (not (client-cert? ctx))
    :as        :text})
 
-(defn- request-opts [{:keys [username password ca-cert client-cert client-key token token-fn] :as ctx}
-                     {:keys [method body] :as req}]
-  (cond-> (default-request-opts ctx req)
+(defn- request-auth-opts [{:keys [username password ca-cert client-cert client-key token token-fn] :as ctx} opts]
+  (cond
     (basic-auth? ctx)
-    (assoc :basic-auth (new-basic-auth-token username password))
+    {:basic-auth (new-basic-auth-token username password)}
 
     (client-cert? ctx)
-    (assoc :sslengine (new-ssl-engine ca-cert client-cert client-key))
+    {:sslengine (new-ssl-engine ca-cert client-cert client-key)}
 
     (token? ctx)
-    (assoc :oauth-token token)
+    {:oauth-token token}
 
     (token-fn? ctx)
-    (assoc :oauth-token (token-fn ctx req))
+    {:oauth-token (token-fn ctx opts)}))
 
-    (some? body)
-    (assoc :body    (json/write-str body)
-           :headers {"Content-Type" (content-type method)})))
+(defn- request-body-opts [{:keys [method body]}]
+  (when (some? body)
+    {:body    (json/write-str body)
+     :headers {"Content-Type" (content-type method)}}))
+
+(defn- request-opts [ctx opts]
+  (merge (default-request-opts ctx opts)
+         (request-auth-opts ctx opts)
+         (request-body-opts opts)))
 
 (defn request [ctx opts]
   (let [c (chan)]

--- a/src/kubernetes/api/util.clj
+++ b/src/kubernetes/api/util.clj
@@ -58,13 +58,16 @@
 (defn- token? [{:keys [token]}]
   (some? token))
 
+(defn- token-fn? [{:keys [token-fn]}]
+  (some? token-fn))
+
 (defn- default-request-opts [ctx {:keys [method path params query]}]
   {:url       (url ctx path params query)
    :method    method
    :insecure? (not (client-cert? ctx))
    :as        :text})
 
-(defn- request-opts [{:keys [username password ca-cert client-cert client-key token] :as ctx}
+(defn- request-opts [{:keys [username password ca-cert client-cert client-key token token-fn] :as ctx}
                      {:keys [method body] :as req}]
   (cond-> (default-request-opts ctx req)
     (basic-auth? ctx)
@@ -75,6 +78,9 @@
 
     (token? ctx)
     (assoc :oauth-token token)
+
+    (token-fn? ctx)
+    (assoc :oauth-token (token-fn ctx req))
 
     (some? body)
     (assoc :body    (json/write-str body)

--- a/test/kubernetes/api/util_test.clj
+++ b/test/kubernetes/api/util_test.clj
@@ -45,6 +45,13 @@
   (testing "when the context does not have a token, it returns false"
     (is (false? (#'util/token? {})))))
 
+(deftest token-fn-test
+  (testing "when the context has a token-fn, it returns true"
+    (is (true? (#'util/token-fn? {:token-fn (fn [ctx req] "token")}))))
+
+  (testing "when the context does not have a token-fn, it returns false"
+    (is (false? (#'util/token-fn? {})))))
+
 (deftest default-request-opts-test
   (let [ctx {:server "http://kubernetes-api"}
         req {:method :get
@@ -97,6 +104,21 @@
                 :path   "/foo"}
           opts (#'util/request-opts ctx req)]
       (is (= "token" (:oauth-token opts)))))
+
+  (testing "when using a function to dynamically generate the bearer token"
+    (let [ctx  {:token-fn (fn [ctx req] "dynamic-token")}
+          req  {:method :get
+                :path   "/foo"}
+          opts (#'util/request-opts ctx req)]
+      (is (= "dynamic-token" (:oauth-token opts)))))
+
+  (testing "when both token and token-fn are provided, the value returned by token fn is used"
+    (let [ctx  {:token    "static-token"
+                :token-fn (fn [ctx req] "dynamic-token")}
+          req  {:method :get
+                :path   "/foo"}
+          opts (#'util/request-opts ctx req)]
+      (is (= "dynamic-token" (:oauth-token opts)))))
 
   (testing "when the request has a body"
     (let [ctx {:token "token"}


### PR DESCRIPTION
With this, we can provide a function in the context (`token-fn`) that takes two arguments - the context and http request options - and returns a bearer token.

An use case for this would be invoking `heptio-authenticator-aws` to generate a new token every time we perform a request.