### PR TITLE
Add patch-type parameter to util/content-type

### DIFF
--- a/src/kubernetes/api/swagger.clj
+++ b/src/kubernetes/api/swagger.clj
@@ -86,6 +86,7 @@
            :path ~path
            :params (select-keys opts# path-params#)
            :query (select-keys opts# query-params#)
+           :patch-type (:patch-type opts#)
            :body body#})))))
 
 (defn render-api [{:keys [operations] :as api}]


### PR DESCRIPTION
# Description
This allows to specify what value should be used in the Content-Type header for PATCH requests. This way we can PATCH CRDs, which doesn't support `application/strategic-merge-patch+json`.

# Tests
Run `lein test :only kubernetes.api.util-test`.
