### PR TITLE
[CICDELIV-901] Add initial implementation for argoproj_io_v1alpha1 API namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,29 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+.nrepl-history
+.rebel_readline_history
+.cpcache/
+profiles.clj
 .hgignore
 .hg/
 *.iml
 *.swp
+.swo
+.swn
 .idea/*
+.idea/
+.vscode/
+.calva/
+.lsp/
+.clj-kondo/
+
+# macOS
+.DS_Store
+
+# Emacs backups
+*~
+\#*\#
+.\#*
 
 doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
-## [1.14.0] - 2025-09-04
+## [1.15.0] - 2025-09-04
 ### Added
 - Add argoproj_io_v1alpha1 namespace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
+## [1.14.0] - 2025-09-04
+### Added
+- Add argoproj_io_v1alpha1 namespace
+
 ## [1.14.0] - 2023-11-17
 ### Added
 - Add batch/v1 namespace

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/kubernetes-api "1.14.0"
+(defproject nubank/kubernetes-api "1.15.0"
   :description "Kubernetes Client API Library"
   :url "https://github.com/nubank/clj-kubernetes-api"
   :license {:name "MIT"

--- a/resources/swagger/argoproj_io_v1alpha1.json
+++ b/resources/swagger/argoproj_io_v1alpha1.json
@@ -1,0 +1,10632 @@
+{
+  "swaggerVersion": "1.2",
+  "apis": [
+    {
+      "path": "/apis/argoproj.io/v1alpha1/analysisruns",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind AnalysisRun",
+          "nickname": "listArgoprojIoV1alpha1AnalysisRunForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/appprojects",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind AppProject",
+          "nickname": "listArgoprojIoV1alpha1NamespacedAppProject",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of AppProject",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedAppProject",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create an AppProject",
+          "nickname": "createArgoprojIoV1alpha1NamespacedAppProject",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/workflowtaskresults",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind WorkflowTaskResult",
+          "nickname": "listArgoprojIoV1alpha1WorkflowTaskResultForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/clusteranalysistemplates",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind ClusterAnalysisTemplate",
+          "nickname": "listArgoprojIoV1alpha1ClusterAnalysisTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of ClusterAnalysisTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionClusterAnalysisTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a ClusterAnalysisTemplate",
+          "nickname": "createArgoprojIoV1alpha1ClusterAnalysisTemplate",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/applicationsets",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind ApplicationSet",
+          "nickname": "listArgoprojIoV1alpha1NamespacedApplicationSet",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of ApplicationSet",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedApplicationSet",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create an ApplicationSet",
+          "nickname": "createArgoprojIoV1alpha1NamespacedApplicationSet",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/rollouts",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Rollout",
+          "nickname": "listArgoprojIoV1alpha1RolloutForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflowtemplates",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind WorkflowTemplate",
+          "nickname": "listArgoprojIoV1alpha1NamespacedWorkflowTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of WorkflowTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedWorkflowTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a WorkflowTemplate",
+          "nickname": "createArgoprojIoV1alpha1NamespacedWorkflowTemplate",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/applications",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Application",
+          "nickname": "listArgoprojIoV1alpha1NamespacedApplication",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of Application",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedApplication",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create an Application",
+          "nickname": "createArgoprojIoV1alpha1NamespacedApplication",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflowtaskresults",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind WorkflowTaskResult",
+          "nickname": "listArgoprojIoV1alpha1NamespacedWorkflowTaskResult",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of WorkflowTaskResult",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedWorkflowTaskResult",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a WorkflowTaskResult",
+          "nickname": "createArgoprojIoV1alpha1NamespacedWorkflowTaskResult",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/rollouts/{name}/status",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read status of the specified Rollout",
+          "nickname": "readArgoprojIoV1alpha1NamespacedRolloutStatus",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update status of the specified Rollout",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedRolloutStatus",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace status of the specified Rollout",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedRolloutStatus",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/cronworkflows",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind CronWorkflow",
+          "nickname": "listArgoprojIoV1alpha1CronWorkflowForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/clusteranalysistemplates/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified ClusterAnalysisTemplate",
+          "nickname": "readArgoprojIoV1alpha1ClusterAnalysisTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterAnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified ClusterAnalysisTemplate",
+          "nickname": "patchArgoprojIoV1alpha1ClusterAnalysisTemplate",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterAnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a ClusterAnalysisTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1ClusterAnalysisTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterAnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified ClusterAnalysisTemplate",
+          "nickname": "replaceArgoprojIoV1alpha1ClusterAnalysisTemplate",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterAnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterAnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/experiments",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Experiment",
+          "nickname": "listArgoprojIoV1alpha1ExperimentForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflows",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Workflow",
+          "nickname": "listArgoprojIoV1alpha1NamespacedWorkflow",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of Workflow",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedWorkflow",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a Workflow",
+          "nickname": "createArgoprojIoV1alpha1NamespacedWorkflow",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/analysistemplates/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified AnalysisTemplate",
+          "nickname": "readArgoprojIoV1alpha1NamespacedAnalysisTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified AnalysisTemplate",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedAnalysisTemplate",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete an AnalysisTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedAnalysisTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified AnalysisTemplate",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedAnalysisTemplate",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/rollouts",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Rollout",
+          "nickname": "listArgoprojIoV1alpha1NamespacedRollout",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of Rollout",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedRollout",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a Rollout",
+          "nickname": "createArgoprojIoV1alpha1NamespacedRollout",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/applicationsets/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified ApplicationSet",
+          "nickname": "readArgoprojIoV1alpha1NamespacedApplicationSet",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified ApplicationSet",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedApplicationSet",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete an ApplicationSet",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedApplicationSet",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified ApplicationSet",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedApplicationSet",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/cronworkflows",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind CronWorkflow",
+          "nickname": "listArgoprojIoV1alpha1NamespacedCronWorkflow",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of CronWorkflow",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedCronWorkflow",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a CronWorkflow",
+          "nickname": "createArgoprojIoV1alpha1NamespacedCronWorkflow",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/analysisruns/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified AnalysisRun",
+          "nickname": "readArgoprojIoV1alpha1NamespacedAnalysisRun",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisRun",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified AnalysisRun",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedAnalysisRun",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisRun",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete an AnalysisRun",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedAnalysisRun",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisRun",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified AnalysisRun",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedAnalysisRun",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AnalysisRun",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/experiments/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified Experiment",
+          "nickname": "readArgoprojIoV1alpha1NamespacedExperiment",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Experiment",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified Experiment",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedExperiment",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Experiment",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete an Experiment",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedExperiment",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Experiment",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified Experiment",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedExperiment",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Experiment",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/workflows",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Workflow",
+          "nickname": "listArgoprojIoV1alpha1WorkflowForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflowtasksets",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind WorkflowTaskSet",
+          "nickname": "listArgoprojIoV1alpha1NamespacedWorkflowTaskSet",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of WorkflowTaskSet",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedWorkflowTaskSet",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a WorkflowTaskSet",
+          "nickname": "createArgoprojIoV1alpha1NamespacedWorkflowTaskSet",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/analysistemplates",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind AnalysisTemplate",
+          "nickname": "listArgoprojIoV1alpha1AnalysisTemplateForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/appprojects/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified AppProject",
+          "nickname": "readArgoprojIoV1alpha1NamespacedAppProject",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AppProject",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified AppProject",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedAppProject",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AppProject",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete an AppProject",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedAppProject",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AppProject",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified AppProject",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedAppProject",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the AppProject",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/experiments",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Experiment",
+          "nickname": "listArgoprojIoV1alpha1NamespacedExperiment",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of Experiment",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedExperiment",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create an Experiment",
+          "nickname": "createArgoprojIoV1alpha1NamespacedExperiment",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Experiment",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/clusterworkflowtemplates",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind ClusterWorkflowTemplate",
+          "nickname": "listArgoprojIoV1alpha1ClusterWorkflowTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of ClusterWorkflowTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionClusterWorkflowTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create a ClusterWorkflowTemplate",
+          "nickname": "createArgoprojIoV1alpha1ClusterWorkflowTemplate",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/applicationsets",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind ApplicationSet",
+          "nickname": "listArgoprojIoV1alpha1ApplicationSetForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflowtemplates/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified WorkflowTemplate",
+          "nickname": "readArgoprojIoV1alpha1NamespacedWorkflowTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified WorkflowTemplate",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedWorkflowTemplate",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a WorkflowTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedWorkflowTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified WorkflowTemplate",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedWorkflowTemplate",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/rollouts/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified Rollout",
+          "nickname": "readArgoprojIoV1alpha1NamespacedRollout",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified Rollout",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedRollout",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a Rollout",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedRollout",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified Rollout",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedRollout",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflows/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified Workflow",
+          "nickname": "readArgoprojIoV1alpha1NamespacedWorkflow",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Workflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified Workflow",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedWorkflow",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Workflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a Workflow",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedWorkflow",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Workflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified Workflow",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedWorkflow",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Workflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Workflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/applications",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind Application",
+          "nickname": "listArgoprojIoV1alpha1ApplicationForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/cronworkflows/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified CronWorkflow",
+          "nickname": "readArgoprojIoV1alpha1NamespacedCronWorkflow",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the CronWorkflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified CronWorkflow",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedCronWorkflow",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the CronWorkflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a CronWorkflow",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedCronWorkflow",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the CronWorkflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified CronWorkflow",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedCronWorkflow",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "CronWorkflow",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the CronWorkflow",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/rollouts/{name}/scale",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read scale of the specified Rollout",
+          "nickname": "readArgoprojIoV1alpha1NamespacedRolloutScale",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update scale of the specified Rollout",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedRolloutScale",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace scale of the specified Rollout",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedRolloutScale",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Rollout",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Rollout",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/appprojects",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind AppProject",
+          "nickname": "listArgoprojIoV1alpha1AppProjectForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AppProject",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflowtaskresults/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified WorkflowTaskResult",
+          "nickname": "readArgoprojIoV1alpha1NamespacedWorkflowTaskResult",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskResult",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified WorkflowTaskResult",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedWorkflowTaskResult",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskResult",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a WorkflowTaskResult",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedWorkflowTaskResult",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskResult",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified WorkflowTaskResult",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedWorkflowTaskResult",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskResult",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskResult",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/applications/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified Application",
+          "nickname": "readArgoprojIoV1alpha1NamespacedApplication",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Application",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified Application",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedApplication",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Application",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete an Application",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedApplication",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Application",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified Application",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedApplication",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "Application",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the Application",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/applicationsets/{name}/status",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read status of the specified ApplicationSet",
+          "nickname": "readArgoprojIoV1alpha1NamespacedApplicationSetStatus",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update status of the specified ApplicationSet",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedApplicationSetStatus",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace status of the specified ApplicationSet",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedApplicationSetStatus",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ApplicationSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ApplicationSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/analysisruns",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind AnalysisRun",
+          "nickname": "listArgoprojIoV1alpha1NamespacedAnalysisRun",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of AnalysisRun",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedAnalysisRun",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create an AnalysisRun",
+          "nickname": "createArgoprojIoV1alpha1NamespacedAnalysisRun",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisRun",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/workflowtasksets/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified WorkflowTaskSet",
+          "nickname": "readArgoprojIoV1alpha1NamespacedWorkflowTaskSet",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified WorkflowTaskSet",
+          "nickname": "patchArgoprojIoV1alpha1NamespacedWorkflowTaskSet",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a WorkflowTaskSet",
+          "nickname": "deleteArgoprojIoV1alpha1NamespacedWorkflowTaskSet",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified WorkflowTaskSet",
+          "nickname": "replaceArgoprojIoV1alpha1NamespacedWorkflowTaskSet",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the WorkflowTaskSet",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/clusterworkflowtemplates/{name}",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "read the specified ClusterWorkflowTemplate",
+          "nickname": "readArgoprojIoV1alpha1ClusterWorkflowTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterWorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json-patch+json",
+            "application/merge-patch+json",
+            "application/apply-patch+yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "partially update the specified ClusterWorkflowTemplate",
+          "nickname": "patchArgoprojIoV1alpha1ClusterWorkflowTemplate",
+          "method": "PATCH",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterWorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint. This field is required for apply requests (application/apply-patch) but optional for non-apply patch types (JsonPatch, MergePatch, StrategicMergePatch).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "force",
+              "description": "Force is going to \"force\" Apply requests. It means user will re-acquire conflicting fields owned by other people. Force flag must be unset for non-apply patch requests.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete a ClusterWorkflowTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1ClusterWorkflowTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterWorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "gracePeriodSeconds",
+              "description": "The duration in seconds before the object should be deleted. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used. Defaults to a per object value if not specified. zero means delete immediately.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "ignoreStoreReadErrorWithClusterBreakingPotential",
+              "description": "if set to true, it will trigger an unsafe deletion of the resource in case the normal deletion flow fails with a corrupt object error. A resource is considered corrupt if it can not be retrieved from the underlying storage successfully because of a) its data can not be transformed e.g. decryption failure, or b) it fails to decode into an object. NOTE: unsafe deletion ignores finalizer constraints, skips precondition checks, and removes the object from the storage. WARNING: This may potentially break the cluster if the workload associated with the resource being unsafe-deleted relies on normal deletion flow. Use only if you REALLY know what you are doing. The default value is false, and the user must opt in to enable it",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "orphanDependents",
+              "description": "Deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the \"orphan\" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "propagationPolicy",
+              "description": "Whether and how garbage collection will be performed. Either this field or OrphanDependents may be set, but not both. The default policy is decided by the existing finalizer set in the metadata.finalizers and the resource-specific default policy. Acceptable values are: 'Orphan' - orphan the dependents; 'Background' - allow the garbage collector to delete the dependents in the background; 'Foreground' - a cascading policy that deletes all dependents in the foreground.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "replace the specified ClusterWorkflowTemplate",
+          "nickname": "replaceArgoprojIoV1alpha1ClusterWorkflowTemplate",
+          "method": "PUT",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "ClusterWorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "name",
+              "description": "name of the ClusterWorkflowTemplate",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/workflowtemplates",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind WorkflowTemplate",
+          "nickname": "listArgoprojIoV1alpha1WorkflowTemplateForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/workflowtasksets",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind WorkflowTaskSet",
+          "nickname": "listArgoprojIoV1alpha1WorkflowTaskSetForAllNamespaces",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "WorkflowTaskSet",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "path": "/apis/argoproj.io/v1alpha1/namespaces/{namespace}/analysistemplates",
+      "operations": [
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "list objects of kind AnalysisTemplate",
+          "nickname": "listArgoprojIoV1alpha1NamespacedAnalysisTemplate",
+          "method": "GET",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "delete collection of AnalysisTemplate",
+          "nickname": "deleteArgoprojIoV1alpha1CollectionNamespacedAnalysisTemplate",
+          "method": "DELETE",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "allowWatchBookmarks",
+              "description": "allowWatchBookmarks requests watch events with type \"BOOKMARK\". Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server's discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "continue",
+              "description": "The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the \"next key\".\n\nThis field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldSelector",
+              "description": "A selector to restrict the list of returned objects by their fields. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "labelSelector",
+              "description": "A selector to restrict the list of returned objects by their labels. Defaults to everything.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "limit",
+              "description": "limit is a maximum number of responses to return for a list call. If more items exist, the server will set the `continue` field on the list metadata to a value that can be used with the same initial query to retrieve the next set of results. Setting a limit may return fewer than the requested amount of items (up to zero items) in the event all requested objects are filtered out and clients should only use the presence of the continue field to determine whether more results are available. Servers may choose not to support the limit argument and will return all of the available results. If limit is specified and the continue field is empty, clients may assume that no more results are available. This field is not supported if watch is true.\n\nThe server guarantees that the objects returned when using continue will be identical to issuing a single list call without a limit - that is, no objects created, modified, or deleted after the first request is issued will be included in any subsequent continued requests. This is sometimes referred to as a consistent snapshot, and ensures that a client that is using limit to receive smaller chunks of a very large result can ensure they see all possible objects. If objects are updated during a chunked list the version of the object that was present at the time the first list result was calculated is returned.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersion",
+              "description": "resourceVersion sets a constraint on what resource versions a request may be served from. See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "resourceVersionMatch",
+              "description": "resourceVersionMatch determines how resourceVersion is applied to list calls. It is highly recommended that resourceVersionMatch be set for list calls where resourceVersion is set See https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-versions for details.\n\nDefaults to unset",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "sendInitialEvents",
+              "description": "`sendInitialEvents=true` may be set together with `watch=true`. In that case, the watch stream will begin with synthetic events to produce the current state of objects in the collection. Once all such events have been sent, a synthetic \"Bookmark\" event  will be sent. The bookmark will report the ResourceVersion (RV) corresponding to the set of objects, and be marked with `\"k8s.io/initial-events-end\": \"true\"` annotation. Afterwards, the watch stream will proceed as usual, sending watch events corresponding to changes (subsequent to the RV) to objects watched.\n\nWhen `sendInitialEvents` option is set, we require `resourceVersionMatch` option to also be set. The semantic of the watch request is as following: - `resourceVersionMatch` = NotOlderThan\n  is interpreted as \"data at least as new as the provided `resourceVersion`\"\n  and the bookmark event is send when the state is synced\n  to a `resourceVersion` at least as fresh as the one provided by the ListOptions.\n  If `resourceVersion` is unset, this is interpreted as \"consistent read\" and the\n  bookmark event is send when the state is synced at least to the moment\n  when request started being processed.\n- `resourceVersionMatch` set to any other value or unset\n  Invalid error is returned.\n\nDefaults to true if `resourceVersion=\"\"` or `resourceVersion=\"0\"` (for backward compatibility reasons) and to false otherwise.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "integer",
+              "paramType": "query",
+              "name": "timeoutSeconds",
+              "description": "Timeout for the list/watch call. This limits the duration of the call, regardless of any activity or inactivity.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "boolean",
+              "paramType": "query",
+              "name": "watch",
+              "description": "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        },
+        {
+          "type": "",
+          "consumes": [
+            "application/json",
+            "application/yaml"
+          ],
+          "produces": [
+            "application/json",
+            "application/yaml"
+          ],
+          "summary": "create an AnalysisTemplate",
+          "nickname": "createArgoprojIoV1alpha1NamespacedAnalysisTemplate",
+          "method": "POST",
+          "x-kubernetes-group-version-kind": {
+            "group": "argoproj.io",
+            "kind": "AnalysisTemplate",
+            "version": "v1alpha1"
+          },
+          "parameters": [
+            {
+              "type": "string",
+              "paramType": "path",
+              "name": "namespace",
+              "description": "object name and auth scope, such as for teams and projects",
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "pretty",
+              "description": "If 'true', then the output is pretty printed. Defaults to 'false' unless the user-agent indicates a browser or command-line HTTP tool (curl and wget).",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": null,
+              "paramType": "body",
+              "name": "body",
+              "description": null,
+              "required": true,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "dryRun",
+              "description": "When present, indicates that modifications should not be persisted. An invalid or unrecognized dryRun directive will result in an error response and no further processing of the request. Valid values are: - All: all dry run stages will be processed",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldManager",
+              "description": "fieldManager is a name associated with the actor or entity that is making these changes. The value must be less than or 128 characters long, and only contain printable characters, as defined by https://golang.org/pkg/unicode/#IsPrint.",
+              "required": null,
+              "allowMultiple": false
+            },
+            {
+              "type": "string",
+              "paramType": "query",
+              "name": "fieldValidation",
+              "description": "fieldValidation instructs the server on how to handle objects in the request (POST/PUT/PATCH) containing unknown or duplicate fields. Valid values are: - Ignore: This will ignore any unknown fields that are silently dropped from the object, and will ignore all but the last duplicate field that the decoder encounters. This is the default behavior prior to v1.23. - Warn: This will send a warning via the standard warning response header for each unknown field that is dropped from the object, and for each duplicate field that is encountered. The request will still succeed if there are no other errors, and will only persist the last of any duplicate fields. This is the default in v1.23+ - Strict: This will fail the request with a BadRequest error if any unknown fields would be dropped from the object, or if any duplicate fields are present. The error returned from the server will contain all unknown and duplicate fields encountered.",
+              "required": null,
+              "allowMultiple": false
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/kubernetes/api/argoproj_io_v1alpha1.clj
+++ b/src/kubernetes/api/argoproj_io_v1alpha1.clj
@@ -1,0 +1,7 @@
+(ns kubernetes.api.argoproj-io-v1alpha1
+  (:require [kubernetes.api.swagger :as swagger]
+            [kubernetes.api.util :as util]))
+
+(def make-context util/make-context)
+
+(swagger/render-full-api "argoproj_io_v1alpha1")


### PR DESCRIPTION
This pull request adds a new namespace for the Argo Project's Kubernetes API integration. The main change is the creation of the `kubernetes.api.argoproj-io-v1alpha1` namespace, which sets up context and rendering utilities for working with the Argo API.

Argo API integration:

* Added new namespace `kubernetes.api.argoproj-io-v1alpha1` with required dependencies for Swagger and utility functions.
* Defined `make-context` for context creation using shared utility.
* Added Swagger API rendering for the `argoproj_io_v1alpha1` group.